### PR TITLE
Add support for custom CanonicalManager

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@atomic-ehr/codegen",
       "dependencies": {
-        "@atomic-ehr/fhir-canonical-manager": "^0.0.10",
+        "@atomic-ehr/fhir-canonical-manager": "0.0.11-canary.355d62d.20250926143544",
         "@atomic-ehr/fhirschema": "^0.0.2",
         "@inquirer/prompts": "^7.8.1",
         "ajv": "^8.17.1",
@@ -24,7 +24,7 @@
     },
   },
   "packages": {
-    "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.10", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-c4iItoLkNy3zt50rx90RmBatF40jz2PxLfxTpHn25Ka7s0YtNKlQ6SZF13khcvszCYEPOPXDxRoU/hcYd0uzqg=="],
+    "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.11-canary.355d62d.20250926143544", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-3FOfV7yyPhkcQ5ug+uE7ESp2ZmM2nVTEI73geOT5uqqi3lBd+G22tZA/HVUaPm2mTbcjQ0KWERG1J+3qxzoB1g=="],
 
     "@atomic-ehr/fhirschema": ["@atomic-ehr/fhirschema@0.0.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-OA4CVjTUEdw43Efg5I5rj95je4GC3lRiLM/kUqadcK3Po24vnINUsB8YdOP/F3ffdUYKQcJ+z09sWQVeAC2z/A=="],
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@atomic-ehr/fhir-canonical-manager": "^0.0.10",
+    "@atomic-ehr/fhir-canonical-manager": "0.0.11-canary.355d62d.20250926143544",
     "@atomic-ehr/fhirschema": "^0.0.2",
     "@inquirer/prompts": "^7.8.1",
     "ajv": "^8.17.1",

--- a/src/api/builder.ts
+++ b/src/api/builder.ts
@@ -15,6 +15,7 @@ import type { TypeSchema } from "@typeschema/types";
 import type { CodegenLogger } from "../utils/codegen-logger";
 import { createLogger } from "../utils/codegen-logger";
 import { TypeScriptGenerator } from "./generators/typescript";
+import type { CanonicalManager } from "@atomic-ehr/fhir-canonical-manager";
 
 /**
  * Configuration options for the API builder
@@ -27,7 +28,7 @@ export interface APIBuilderOptions {
   cache?: boolean;
   typeSchemaConfig?: TypeSchemaConfig;
   logger?: CodegenLogger;
-  manager?: ReturnType<typeof import("@atomic-ehr/fhir-canonical-manager").CanonicalManager> | null;
+  manager?: ReturnType<typeof CanonicalManager> | null;
 }
 
 /**

--- a/src/api/builder.ts
+++ b/src/api/builder.ts
@@ -27,6 +27,7 @@ export interface APIBuilderOptions {
   cache?: boolean;
   typeSchemaConfig?: TypeSchemaConfig;
   logger?: CodegenLogger;
+  manager?: ReturnType<typeof import("@atomic-ehr/fhir-canonical-manager").CanonicalManager> | null;
 }
 
 /**
@@ -82,6 +83,7 @@ export class APIBuilder {
       validate: options.validate ?? true,
       cache: options.cache ?? true,
       typeSchemaConfig: options.typeSchemaConfig,
+      manager: options.manager || null,
     };
 
     this.typeSchemaConfig = options.typeSchemaConfig;
@@ -350,6 +352,7 @@ export class APIBuilder {
         verbose: this.options.verbose,
         logger: this.logger.child("Schema"),
         treeshake: this.typeSchemaConfig?.treeshake,
+        manager: this.options.manager,
       },
       this.typeSchemaConfig,
     );

--- a/src/typeschema/generator.ts
+++ b/src/typeschema/generator.ts
@@ -33,6 +33,7 @@ import { transformValueSet } from "./value-set/processor";
  */
 export class TypeSchemaGenerator {
   private manager: ReturnType<typeof CanonicalManager>;
+
   private options: TypeschemaGeneratorOptions;
   private cacheConfig?: TypeSchemaConfig;
   private cache?: TypeSchemaCache;
@@ -43,7 +44,8 @@ export class TypeSchemaGenerator {
     cacheConfig?: TypeSchemaConfig,
   ) {
     this.options = { verbose: false, ...options };
-    this.manager = CanonicalManager({ packages: [], workingDir: "tmp/fhir" });
+    this.manager = options.manager || 
+      CanonicalManager({ packages: [], workingDir: "tmp/fhir" });
     this.cacheConfig = cacheConfig;
     this.logger =
       options.logger ||
@@ -71,12 +73,7 @@ export class TypeSchemaGenerator {
     this.logger.step(
       `Loading FHIR package: ${packageName}${packageVersion ? `@${packageVersion}` : ""}`,
     );
-
-    this.manager = CanonicalManager({
-      packages: [`${packageName}${packageVersion ? `@${packageVersion}` : ""}`],
-      workingDir: "tmp/fhir",
-    });
-    await this.manager.init();
+    await this.manager.addPackages(`${packageName}${packageVersion ? `@${packageVersion}` : ""}`);
 
     const allResources = await this.manager.search({});
 

--- a/src/typeschema/types.ts
+++ b/src/typeschema/types.ts
@@ -18,9 +18,9 @@ export const enrichFHIRSchema = (schema: FS.FHIRSchema): RichFHIRSchema => {
   return {
     ...schema,
     package_meta: {
-      name: schema.package_name || schema.package_meta.name || "undefined",
+      name: schema.package_name || schema.package_meta?.name || "undefined",
       version:
-        schema.package_version || schema.package_meta.version || "undefined",
+        schema.package_version || schema.package_meta?.version || "undefined",
     },
   };
 };
@@ -215,6 +215,7 @@ export interface TypeschemaGeneratorOptions {
   verbose?: boolean;
   logger?: import("../utils/codegen-logger").CodegenLogger;
   treeshake?: string[];
+  manager?: ReturnType<typeof import("@atomic-ehr/fhir-canonical-manager").CanonicalManager> | null;
 }
 
 export function isBindingSchema(

--- a/src/typeschema/types.ts
+++ b/src/typeschema/types.ts
@@ -4,6 +4,7 @@
  */
 
 import type * as FS from "@atomic-ehr/fhirschema";
+import type { CanonicalManager } from "@atomic-ehr/fhir-canonical-manager";
 
 export interface PackageInfo {
   name: string;
@@ -215,7 +216,7 @@ export interface TypeschemaGeneratorOptions {
   verbose?: boolean;
   logger?: import("../utils/codegen-logger").CodegenLogger;
   treeshake?: string[];
-  manager?: ReturnType<typeof import("@atomic-ehr/fhir-canonical-manager").CanonicalManager> | null;
+  manager?: ReturnType<typeof CanonicalManager> | null;
 }
 
 export function isBindingSchema(


### PR DESCRIPTION
## Add support for custom CanonicalManager

This PR adds support for injecting a custom `CanonicalManager` via the `APIBuilderOptions` interface and the `APIBuilder` constructor. This enables advanced use cases where a pre-configured or shared manager instance is required for FHIR package handling.

**Reference:** [atomic-ehr/codegen#2](https://github.com/atomic-ehr/codegen/issues/2)

---
- Adds `manager` option to `APIBuilderOptions`
- Passes `manager` to `TypeSchemaGenerator` when loading FHIR packages

No breaking changes. Existing functionality remains unaffected if no manager is provided.

Needs the following pull request: https://github.com/atomic-ehr/fhir-canonical-manager/pull/1