### PR TITLE
Replace hyphens with underscores in field names

### DIFF
--- a/src/api/generators/typescript.ts
+++ b/src/api/generators/typescript.ts
@@ -757,7 +757,7 @@ export class TypeScriptGenerator extends BaseGenerator<TypeScriptGeneratorOption
         const optional = required ? "" : "?";
         const arrayType = isArray ? "[]" : "";
 
-        return `${fieldName}${optional}: ${typeString}${arrayType};`;
+        return `${fieldName.replace("-", "_")}${optional}: ${typeString}${arrayType};`;
     }
 
     // ==========================================


### PR DESCRIPTION
Some CCDA types have hyphens in them instead of TypeScript-friendly underscores. See #11 for the context.

I don't like this fix (it's too late in the pipeline, should rather be in the typeschema processing,) but it's fastest I can do without understanding all of the typeschema infra. If you have a better understanding of where this error manifests, then please forget about this PR and fix it. Thanks you 🖤 