### PR TITLE
Add configurable log levels in CLI and API

### DIFF
--- a/examples/csharp/generate.ts
+++ b/examples/csharp/generate.ts
@@ -4,7 +4,6 @@ if (require.main === module) {
     console.log("📦 Generating FHIR R4 Core Types...");
 
     const builder = new APIBuilder()
-        .verbose()
         .throwException()
         .fromPackage("hl7.fhir.r4.core", "4.0.1")
         .csharp("SuperNameSpace", "src/api/writer-generator/csharp/staticFiles")

--- a/examples/typescript-ccda/generate.ts
+++ b/examples/typescript-ccda/generate.ts
@@ -7,7 +7,6 @@ if (require.main === module) {
     console.log("📦 Generating FHIR R4 Core Types...");
 
     const builder = new APIBuilder()
-        .verbose()
         .throwException()
         .fromPackage("hl7.cda.uv.core", "2.0.1-sd")
         .typescript({ withDebugComment: false })

--- a/examples/typescript-r4/generate.ts
+++ b/examples/typescript-r4/generate.ts
@@ -7,7 +7,6 @@ if (require.main === module) {
     console.log("📦 Generating FHIR R4 Core Types...");
 
     const builder = new APIBuilder()
-        .verbose()
         .throwException()
         .fromPackage("hl7.fhir.r4.core", "4.0.1")
         .typescript({

--- a/examples/typescript-sql-on-fhir/generate.ts
+++ b/examples/typescript-sql-on-fhir/generate.ts
@@ -1,7 +1,6 @@
 import { APIBuilder } from "../../src/api/builder";
 
 const builder = new APIBuilder()
-    .verbose()
     .throwException()
     .typescript({ withDebugComment: false, generateProfile: false })
     .fromPackageRef("https://build.fhir.org/ig/FHIR/sql-on-fhir-v2//package.tgz")

--- a/src/api/builder.ts
+++ b/src/api/builder.ts
@@ -15,7 +15,7 @@ import { mkTypeSchemaIndex, type TreeShake, type TypeSchemaIndex, treeShake } fr
 import { generateTypeSchemas } from "@typeschema/index";
 import { extractNameFromCanonical, packageMetaToFhir, packageMetaToNpm, type TypeSchema } from "@typeschema/types";
 import type { TypeSchemaConfig } from "../config";
-import { CodegenLogger, createLogger } from "../utils/codegen-logger";
+import { CodegenLogger, createLogger, type LogLevel } from "../utils/codegen-logger";
 import { TypeScript, type TypeScriptOptions } from "./writer-generator/typescript";
 import type { FileBuffer, FileSystemWriter, WriterOptions } from "./writer-generator/writer";
 
@@ -24,7 +24,6 @@ import type { FileBuffer, FileSystemWriter, WriterOptions } from "./writer-gener
  */
 export interface APIBuilderOptions {
     outputDir?: string;
-    verbose?: boolean;
     overwrite?: boolean; // FIXME: remove
     cache?: boolean; // FIXME: remove
     cleanOutput?: boolean;
@@ -35,6 +34,8 @@ export interface APIBuilderOptions {
     throwException?: boolean;
     exportTypeTree?: string;
     treeShake?: TreeShake;
+    /** Log level for the logger. Default: INFO */
+    logLevel?: LogLevel;
 }
 
 /**
@@ -70,7 +71,7 @@ export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 type APIBuilderConfig = PartialBy<
     Required<APIBuilderOptions>,
-    "logger" | "typeSchemaConfig" | "typeSchemaOutputDir" | "exportTypeTree" | "treeShake"
+    "logger" | "typeSchemaConfig" | "typeSchemaOutputDir" | "exportTypeTree" | "treeShake" | "logLevel"
 > & {
     cleanOutput: boolean;
 };
@@ -188,7 +189,6 @@ export class APIBuilder {
     constructor(options: APIBuilderOptions = {}) {
         this.options = {
             outputDir: options.outputDir || "./generated",
-            verbose: options.verbose ?? false,
             overwrite: options.overwrite ?? true,
             cache: options.cache ?? true,
             cleanOutput: options.cleanOutput ?? true,
@@ -206,8 +206,8 @@ export class APIBuilder {
         this.logger =
             options.logger ||
             createLogger({
-                verbose: this.options.verbose,
                 prefix: "API",
+                level: options.logLevel,
             });
     }
 
@@ -259,7 +259,6 @@ export class APIBuilder {
             logger: new CodegenLogger({
                 prefix: "C#",
                 timestamp: true,
-                verbose: true,
                 suppressLoggingLevel: [],
             }),
         });
@@ -291,9 +290,8 @@ export class APIBuilder {
         return this;
     }
 
-    verbose(enabled = true): APIBuilder {
-        this.options.verbose = enabled;
-        this.logger?.configure({ verbose: enabled });
+    setLogLevel(level: LogLevel): APIBuilder {
+        this.logger?.setLevel(level);
         return this;
     }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,7 @@
  * @packageDocumentation
  */
 
+export { LogLevel } from "../utils/codegen-logger";
 export type { APIBuilderOptions } from "./builder";
 export { APIBuilder } from "./builder";
 export type { CSharpGeneratorOptions } from "./writer-generator/csharp/csharp";

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -73,7 +73,6 @@ export const generateCommand: CommandModule<Record<string, unknown>, GenerateArg
 
         // Create logger for CLI command
         const logger = createLogger({
-            verbose,
             prefix: "Generate",
         });
 
@@ -90,7 +89,6 @@ export const generateCommand: CommandModule<Record<string, unknown>, GenerateArg
             // Create API builder with config options
             const builder = new APIBuilder({
                 outputDir: config.outputDir || "./generated",
-                verbose,
                 overwrite: config.overwrite ?? true,
                 cache: config.cache ?? true,
                 typeSchemaConfig: config.typeSchema,

--- a/src/cli/commands/typeschema/generate.ts
+++ b/src/cli/commands/typeschema/generate.ts
@@ -67,7 +67,6 @@ export const generateTypeschemaCommand: CommandModule<Record<string, unknown>, G
     },
     handler: async (argv) => {
         const logger = createLogger({
-            verbose: argv.verbose,
             prefix: "TypeSchema",
         });
 
@@ -103,7 +102,6 @@ export const generateTypeschemaCommand: CommandModule<Record<string, unknown>, G
 
             // Create TypeSchema generator
             const generator = new TypeSchemaGenerator({
-                verbose: argv.verbose,
                 treeshake: treeshakeOptions,
             });
 

--- a/src/typeschema/generator.ts
+++ b/src/typeschema/generator.ts
@@ -30,16 +30,16 @@ import {
 export class TypeSchemaGenerator {
     private manager: ReturnType<typeof CanonicalManager>;
 
+    // biome-ignore lint/correctness/noUnusedPrivateClassMembers: currently its okay
     private options: TypeschemaGeneratorOptions;
     private logger?: CodegenLogger;
 
     constructor(options: TypeschemaGeneratorOptions = {}) {
-        this.options = { verbose: false, ...options };
+        this.options = { ...options };
         this.manager = options.manager || CanonicalManager({ packages: [], workingDir: "tmp/fhir" });
         this.logger =
             options.logger ||
             createLogger({
-                verbose: this.options.verbose,
                 prefix: "TypeSchema",
             });
     }

--- a/src/typeschema/types.ts
+++ b/src/typeschema/types.ts
@@ -384,7 +384,6 @@ export const enrichValueSet = (vs: ValueSet, packageMeta: PackageMeta): RichValu
 ///////////////////////////////////////////////////////////
 
 export interface TypeschemaGeneratorOptions {
-    verbose?: boolean;
     logger?: import("../utils/codegen-logger").CodegenLogger;
     treeshake?: string[];
     manager?: ReturnType<typeof CanonicalManager> | null;

--- a/test/unit/typeschema/utils.ts
+++ b/test/unit/typeschema/utils.ts
@@ -13,7 +13,7 @@ import {
 export type PFS = Partial<FHIRSchema>;
 export type PVS = Partial<ValueSet>;
 
-const logger = createLogger({ verbose: true, prefix: "TEST" });
+const logger = createLogger({ prefix: "TEST" });
 
 export const r4Package = { name: "hl7.fhir.r4.core", version: "4.0.1" };
 


### PR DESCRIPTION
- Introduced `--log-level` option in CLI for granular logging control.
- Enhanced `CodegenLogger` to support log levels (DEBUG, INFO, WARN, ERROR, SILENT).
- Updated APIBuilder to allow log level configuration.