### PR TITLE
BRK: ts: don't process logic model like resource

### DIFF
--- a/examples/typescript-ccda/generate.ts
+++ b/examples/typescript-ccda/generate.ts
@@ -23,7 +23,7 @@ if (require.main === module) {
     const builder = new APIBuilder({ manager: registry })
         .throwException()
         .promoteLogicToResource({ "hl7.cda.uv.core": cdaResources })
-        .typescript({ withDebugComment: false, resourceTypeFieldForLogicalResource: false })
+        .typescript({ withDebugComment: false })
         .outputTo("./examples/typescript-ccda/fhir-types")
         .introspection({
             typeSchemas: "type-schemas",

--- a/src/api/builder.ts
+++ b/src/api/builder.ts
@@ -227,7 +227,6 @@ export class APIBuilder {
             ...defaultWriterOpts,
             openResourceTypeSet: false,
             primitiveTypeExtension: true,
-            resourceTypeFieldForLogicalResource: true,
         };
         const opts: TypeScriptOptions = {
             ...defaultTsOpts,

--- a/src/api/writer-generator/typescript.ts
+++ b/src/api/writer-generator/typescript.ts
@@ -184,7 +184,6 @@ export type TypeScriptOptions = {
      */
     openResourceTypeSet: boolean;
     primitiveTypeExtension: boolean;
-    resourceTypeFieldForLogicalResource: boolean;
 } & WriterOptions;
 
 export class TypeScript extends Writer<TypeScriptOptions> {
@@ -232,8 +231,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
                                   ? schema.nested.map((n) => tsResourceName(n.identifier))
                                   : []),
                           ];
-                    const valueExports =
-                        isResourceTypeSchema(schema) || this.isLogicalLikeResource(schema) ? [`is${resourceName}`] : [];
+                    const valueExports = isResourceTypeSchema(schema) ? [`is${resourceName}`] : [];
 
                     return [
                         {
@@ -347,7 +345,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
             return;
         }
         this.curlyBlock(["export", "interface", name, extendsClause], () => {
-            if (isResourceTypeSchema(schema) || this.isLogicalLikeResource(schema)) {
+            if (isResourceTypeSchema(schema)) {
                 const possibleResourceTypes = [schema.identifier];
                 possibleResourceTypes.push(...tsIndex.resourceChildren(schema.identifier));
                 const openSetSuffix =
@@ -410,12 +408,8 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         return false;
     }
 
-    isLogicalLikeResource(schema: RegularTypeSchema) {
-        return this.opts.resourceTypeFieldForLogicalResource && isLogicalTypeSchema(schema);
-    }
-
     generateResourceTypePredicate(schema: RegularTypeSchema) {
-        if (!isResourceTypeSchema(schema) && !this.isLogicalLikeResource(schema)) return;
+        if (!isResourceTypeSchema(schema)) return;
         const name = tsResourceName(schema.identifier);
         this.curlyBlock(["export", "const", `is${name}`, "=", `(resource: unknown): resource is ${name}`, "=>"], () => {
             this.lineSM(

--- a/test/api/write-generator/typescript.test.ts
+++ b/test/api/write-generator/typescript.test.ts
@@ -25,7 +25,6 @@ describe("TypeScript CDA with Logical Model Promotion to Resource", async () => 
         })
         .typescript({
             inMemoryOnly: true,
-            resourceTypeFieldForLogicalResource: false,
         })
         .generate();
     expect(result.success).toBeTrue();


### PR DESCRIPTION
Eraly: logical model processed like regular resource, which is not FHIR compliance behaviour.

Changes: 

- logical models processed like complex types (don't add `resourceType` fields and don't generate predicates);
- logical models can be promoted to be processed like resource by type schema level processing: 

```typescript
  .promoteLogicToResource({
    "my.custom.pkg": [
      "http://example.org/StructureDefinition/MyLogicalModel"
    ]
  })
```