### PR TITLE
Export profile base interface alongside the profile class

### DIFF
--- a/examples/typescript-r4/fhir-types/hl7-fhir-r4-core/index.ts
+++ b/examples/typescript-r4/fhir-types/hl7-fhir-r4-core/index.ts
@@ -18,7 +18,6 @@ export type { Meta } from "./Meta";
 export type { Narrative } from "./Narrative";
 export type { Observation, ObservationComponent, ObservationReferenceRange } from "./Observation";
 export { isObservation } from "./Observation";
-export type { observation_vitalsigns } from "./profiles/Observation_vitalsigns";
 export type { OperationOutcome, OperationOutcomeIssue } from "./OperationOutcome";
 export { isOperationOutcome } from "./OperationOutcome";
 export type { Patient, PatientCommunication, PatientContact, PatientLink } from "./Patient";

--- a/examples/typescript-r4/fhir-types/hl7-fhir-r4-core/profiles/index.ts
+++ b/examples/typescript-r4/fhir-types/hl7-fhir-r4-core/profiles/index.ts
@@ -1,2 +1,3 @@
+export type { observation_vitalsigns } from "./Observation_vitalsigns";
 export { Observation_bodyweightProfile } from "./Observation_bodyweight";
 export { Observation_vitalsignsProfile } from "./Observation_vitalsigns";


### PR DESCRIPTION
I was testing CCDA generation and writing tests for it. And I noticed that CCDA profile classes are exported, while interfaces behind them aren’t. Test snippet (added as an extra file in `examples/typescript-ccda/`):

``` typescript
import type * as CCDA from "./fhir-types/hl7-cda-us-ccda";
import type * as FHIR from "./fhir-types/hl7-fhir-r4-core";

function medicationStatementToMedicationActivity (stat: FHIR.MedicationStatement): CCDA.MedicationActivity | null {
    return null;
}
```

it fails with `CCDA.MedicationActivity` not being found. 

-----------------

With this PR, package `index.ts` has all the necessary type exports, like
``` typescript
export type { MedicationActivity } from "./profiles/MedicationActivity";
```