### PR TITLE
Fix: skip choice flattening for primitive variant types

### DIFF
--- a/src/api/writer-generator/typescript/profile.ts
+++ b/src/api/writer-generator/typescript/profile.ts
@@ -771,6 +771,9 @@ const detectConstrainedChoice = (
         const variantField = baseSchema.fields[variantName];
         if (!variantField || !isChoiceInstanceField(variantField)) continue;
 
+        // Skip flattening for primitive types — can't intersect object with boolean/string/etc.
+        if (isPrimitiveIdentifier(variantField.type)) continue;
+
         return {
             choiceBase: fieldName,
             variant: variantName,


### PR DESCRIPTION
- Skip choice type flattening when the constrained variant is a primitive type (boolean, string, etc.)
- Intersecting an object type (`Omit<Extension, ...>`) with a primitive (`& boolean`) produces invalid TypeScript (TS2352)
- Affected profiles (e.g. Norge R4 `SfmpllInformation`) now keep the explicit `value[x]` field instead of flattening