### PR TITLE
TypeSchema: Narrow FieldSlicing discriminator type from string to literal union (refactoring)

### DIFF
--- a/src/typeschema/core/field-builder.ts
+++ b/src/typeschema/core/field-builder.ts
@@ -10,6 +10,7 @@ import type { CodegenLog } from "@root/utils/log";
 import { packageMetaToFhir } from "@typeschema/types";
 import type {
     BindingIdentifier,
+    DiscriminatorType,
     EnumDefinition,
     Field,
     FieldSlice,
@@ -199,8 +200,16 @@ const computeTypeDiscriminatorMatch = (
  * Used when a slice has an empty match but the discriminator values are nested deeper
  * (e.g., component slices in BP where the discriminator crosses a nested slicing boundary).
  */
+const validDiscriminatorTypes = new Set<string>(["value", "exists", "pattern", "type", "profile"]);
+
+// TODO: Update type in FHIR Schema to prevent this casting.
+const toDiscriminators = (
+    raw: { type: string; path: string }[] | undefined,
+): { type: DiscriminatorType; path: string }[] =>
+    (raw ?? []).filter((d) => validDiscriminatorTypes.has(d.type)) as { type: DiscriminatorType; path: string }[];
+
 const computeMatchFromSchema = (
-    discriminators: Array<{ type?: string; path: string }>,
+    discriminators: { type: DiscriminatorType; path: string }[],
     schema: FHIRSchemaElement | undefined,
 ): Record<string, unknown> | undefined => {
     if (!schema || !discriminators || discriminators.length === 0) return undefined;
@@ -230,7 +239,7 @@ const buildSlicing = (element: FHIRSchemaElement): FieldSlicing | undefined => {
             min: slice.min,
             max: slice.max,
             match: isEmptyMatch(slice.match)
-                ? computeMatchFromSchema(slicing.discriminator ?? [], slice.schema)
+                ? computeMatchFromSchema(toDiscriminators(slicing.discriminator), slice.schema)
                 : (slice.match as Record<string, unknown> | undefined),
             required,
             excluded,
@@ -239,7 +248,7 @@ const buildSlicing = (element: FHIRSchemaElement): FieldSlicing | undefined => {
     }
 
     return {
-        discriminator: slicing.discriminator,
+        discriminator: toDiscriminators(slicing.discriminator),
         rules: slicing.rules,
         ordered: slicing.ordered,
         slices: Object.keys(slices).length > 0 ? slices : undefined,

--- a/src/typeschema/types.ts
+++ b/src/typeschema/types.ts
@@ -211,8 +211,10 @@ export interface ProfileTypeSchema {
     nested?: NestedType[];
 }
 
+export type DiscriminatorType = "value" | "exists" | "pattern" | "type" | "profile";
+
 export interface FieldSlicing {
-    discriminator?: Array<{ type?: string; path: string }>;
+    discriminator?: { type: DiscriminatorType; path: string }[];
     rules?: string;
     ordered?: boolean;
     slices?: Record<string, FieldSlice>;


### PR DESCRIPTION
- Add `DiscriminatorType = "value" | "exists" | "pattern" | "type" | "profile"` to `types.ts`
- Narrow `FieldSlicing.discriminator[].type` from `string?` to `DiscriminatorType`
- Update `field-builder.ts` casts to use the new type