### PR TITLE
TypeSchema: Rename RegularTypeSchema to SpecializationTypeSchema

### DIFF
--- a/docs/guides/typeschema-index.md
+++ b/docs/guides/typeschema-index.md
@@ -48,13 +48,13 @@ Why TypeSchemaIndex Matters
 Query schemas by type category:
 
 ```typescript
-collectComplexTypes(): RegularTypeSchema[]
+collectComplexTypes(): SpecializationTypeSchema[]
   Returns all complex types (datatypes, backbone elements)
 
-collectResources(): RegularTypeSchema[]
+collectResources(): SpecializationTypeSchema[]
   Returns all FHIR resources (Patient, Observation, etc.)
 
-collectLogicalModels(): RegularTypeSchema[]
+collectLogicalModels(): SpecializationTypeSchema[]
   Returns all logical models
 
 collectProfiles(): ProfileTypeSchema[]

--- a/src/api/writer-generator/csharp/csharp.ts
+++ b/src/api/writer-generator/csharp/csharp.ts
@@ -5,7 +5,11 @@ import { pascalCase, uppercaseFirstLetter, uppercaseFirstLetterOfEach } from "@r
 import { Writer, type WriterOptions } from "@root/api/writer-generator/writer.ts";
 import type { PartialBy } from "@root/utils/types.ts";
 import type { Field, Identifier, RegularField } from "@typeschema/types";
-import { type ChoiceFieldInstance, isChoiceDeclarationField, type RegularTypeSchema } from "@typeschema/types.ts";
+import {
+    type ChoiceFieldInstance,
+    isChoiceDeclarationField,
+    type SpecializationTypeSchema,
+} from "@typeschema/types.ts";
 import type { TypeSchemaIndex } from "@typeschema/utils.ts";
 import { formatEnumEntry, formatName } from "./formatHelper.ts";
 
@@ -49,12 +53,12 @@ const getFieldModifiers = (field: Field) => {
     return field.required ? ["required"] : [];
 };
 
-const formatClassName = (schema: RegularTypeSchema) => {
+const formatClassName = (schema: SpecializationTypeSchema) => {
     const name = prefixReservedTypeName(getResourceName(schema.identifier));
     return uppercaseFirstLetter(name);
 };
 
-const formatBaseClass = (schema: RegularTypeSchema) => {
+const formatBaseClass = (schema: SpecializationTypeSchema) => {
     return schema.base ? `: ${schema.base.name}` : "";
 };
 
@@ -122,8 +126,8 @@ export class CSharp extends Writer<CSharpGeneratorOptions> {
     }
 
     private generateAllFiles(
-        complexTypes: RegularTypeSchema[],
-        resources: RegularTypeSchema[],
+        complexTypes: SpecializationTypeSchema[],
+        resources: SpecializationTypeSchema[],
         packages: string[],
     ): void {
         this.generateUsingFile(packages);
@@ -134,7 +138,7 @@ export class CSharp extends Writer<CSharpGeneratorOptions> {
         this.generateHelperFile();
     }
 
-    private generateType(schema: RegularTypeSchema, packageName: string): void {
+    private generateType(schema: SpecializationTypeSchema, packageName: string): void {
         const className = formatClassName(schema);
         const baseClass = formatBaseClass(schema);
 
@@ -147,7 +151,7 @@ export class CSharp extends Writer<CSharpGeneratorOptions> {
         this.line();
     }
 
-    private generateFields(schema: RegularTypeSchema, packageName: string): void {
+    private generateFields(schema: SpecializationTypeSchema, packageName: string): void {
         if (!schema.fields) return;
 
         const sortedFields = Object.entries(schema.fields).sort(([a], [b]) => a.localeCompare(b));
@@ -157,7 +161,7 @@ export class CSharp extends Writer<CSharpGeneratorOptions> {
         }
     }
 
-    private generateNestedTypes(schema: RegularTypeSchema, packageName: string): void {
+    private generateNestedTypes(schema: SpecializationTypeSchema, packageName: string): void {
         if (!("nested" in schema) || !schema.nested) return;
 
         this.line();
@@ -257,7 +261,7 @@ export class CSharp extends Writer<CSharpGeneratorOptions> {
         for (const using of globalUsings) this.lineSM("global", "using", using);
     }
 
-    private generateBaseTypes(complexTypes: RegularTypeSchema[]): void {
+    private generateBaseTypes(complexTypes: SpecializationTypeSchema[]): void {
         this.cd("/", async () => {
             this.cat("base.cs", () => {
                 this.generateDisclaimer();
@@ -272,11 +276,11 @@ export class CSharp extends Writer<CSharpGeneratorOptions> {
         });
     }
 
-    private generateResources(resources: RegularTypeSchema[]): void {
+    private generateResources(resources: SpecializationTypeSchema[]): void {
         for (const schema of resources) this.generateResourceFile(schema);
     }
 
-    private generateResourceFile(schema: RegularTypeSchema): void {
+    private generateResourceFile(schema: SpecializationTypeSchema): void {
         const packageName = formatName(schema.identifier.package);
 
         this.cd(`/${packageName}`, async () => {
@@ -328,7 +332,7 @@ export class CSharp extends Writer<CSharpGeneratorOptions> {
         this.line();
     }
 
-    private generateResourceDictionaries(resources: RegularTypeSchema[], packages: string[]): void {
+    private generateResourceDictionaries(resources: SpecializationTypeSchema[], packages: string[]): void {
         this.cd("/", async () => {
             for (const packageName of packages) {
                 const packageResources = resources.filter((r) => formatName(r.identifier.package) === packageName);
@@ -345,7 +349,7 @@ export class CSharp extends Writer<CSharpGeneratorOptions> {
         });
     }
 
-    private generateResourceDictionaryClass(packageName: string, resources: RegularTypeSchema[]): void {
+    private generateResourceDictionaryClass(packageName: string, resources: SpecializationTypeSchema[]): void {
         this.curlyBlock(["public", "static", "class", "ResourceDictionary"], () => {
             this.curlyBlock(["public static readonly Dictionary<Type, string> Map = new()"], () => {
                 for (const schema of resources) {

--- a/src/api/writer-generator/python.ts
+++ b/src/api/writer-generator/python.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { camelCase, pascalCase, snakeCase, uppercaseFirstLetterOfEach } from "@root/api/writer-generator/utils";
 import { Writer, type WriterOptions } from "@root/api/writer-generator/writer.ts";
 import { groupByPackages, sortAsDeclarationSequence, type TypeSchemaIndex } from "@root/typeschema/utils";
-import type { EnumDefinition, Field, Identifier, RegularTypeSchema } from "@typeschema/types.ts";
+import type { EnumDefinition, Field, Identifier, SpecializationTypeSchema } from "@typeschema/types.ts";
 
 const PRIMITIVE_TYPE_MAP: Record<string, string> = {
     boolean: "bool",
@@ -148,8 +148,8 @@ const resolvePyAssets = (fn: string) => {
 };
 
 type TypeSchemaPackageGroups = {
-    groupedResources: Record<string, RegularTypeSchema[]>;
-    groupedComplexTypes: Record<string, RegularTypeSchema[]>;
+    groupedResources: Record<string, SpecializationTypeSchema[]>;
+    groupedComplexTypes: Record<string, SpecializationTypeSchema[]>;
 };
 
 export class Python extends Writer<PythonGeneratorOptions> {
@@ -191,7 +191,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         this.generateResourcePackages(groups);
     }
 
-    private generateComplexTypesPackages(groupedComplexTypes: Record<string, RegularTypeSchema[]>): void {
+    private generateComplexTypesPackages(groupedComplexTypes: Record<string, SpecializationTypeSchema[]>): void {
         for (const [packageName, packageComplexTypes] of Object.entries(groupedComplexTypes)) {
             this.cd(`/${snakeCase(packageName)}`, () => {
                 this.generateBasePy(packageComplexTypes);
@@ -213,8 +213,8 @@ export class Python extends Writer<PythonGeneratorOptions> {
 
     private generateResourcePackageContent(
         packageName: string,
-        packageResources: RegularTypeSchema[],
-        packageComplexTypes: RegularTypeSchema[],
+        packageResources: SpecializationTypeSchema[],
+        packageComplexTypes: SpecializationTypeSchema[],
     ): void {
         const pyPackageName = this.pyFhirPackageByName(packageName);
 
@@ -255,7 +255,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         }
     }
 
-    private generateBasePy(packageComplexTypes: RegularTypeSchema[]): void {
+    private generateBasePy(packageComplexTypes: SpecializationTypeSchema[]): void {
         const hasGenericTypes = packageComplexTypes.some((s) => s.identifier.name in GENERIC_FIELD_REWRITES);
         this.cat("base.py", () => {
             this.generateDisclaimer();
@@ -270,7 +270,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         });
     }
 
-    private generateComplexTypes(complexTypes: RegularTypeSchema[]): void {
+    private generateComplexTypes(complexTypes: SpecializationTypeSchema[]): void {
         for (const schema of sortAsDeclarationSequence(complexTypes)) {
             this.generateNestedTypes(schema);
             this.line();
@@ -280,8 +280,8 @@ export class Python extends Writer<PythonGeneratorOptions> {
 
     private generateResourcePackageInit(
         fullPyPackageName: string,
-        packageResources: RegularTypeSchema[],
-        packageComplexTypes?: RegularTypeSchema[],
+        packageResources: SpecializationTypeSchema[],
+        packageComplexTypes?: SpecializationTypeSchema[],
     ): void {
         this.cat("__init__.py", () => {
             this.generateDisclaimer();
@@ -292,7 +292,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         });
     }
 
-    private importComplexTypes(fullPyPackageName: string, packageComplexTypes?: RegularTypeSchema[]): string[] {
+    private importComplexTypes(fullPyPackageName: string, packageComplexTypes?: SpecializationTypeSchema[]): string[] {
         if (!packageComplexTypes || packageComplexTypes.length === 0) return [];
 
         const baseTypes = packageComplexTypes.map((t) => t.identifier.name).sort();
@@ -323,7 +323,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
     private importResources(
         fullPyPackageName: string,
         importEmptyResources: boolean,
-        packageResources?: RegularTypeSchema[],
+        packageResources?: SpecializationTypeSchema[],
     ): string[] {
         if (!packageResources || packageResources.length === 0) return [];
         const allResourceNames: string[] = [];
@@ -337,7 +337,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         return allResourceNames;
     }
 
-    private importOneResource(resource: RegularTypeSchema, fullPyPackageName: string): string[] {
+    private importOneResource(resource: SpecializationTypeSchema, fullPyPackageName: string): string[] {
         const moduleName = `${fullPyPackageName}.${snakeCase(resource.identifier.name)}`;
         const importNames = this.collectResourceImportNames(resource);
 
@@ -353,7 +353,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         return names;
     }
 
-    private collectResourceImportNames(resource: RegularTypeSchema): string[] {
+    private collectResourceImportNames(resource: SpecializationTypeSchema): string[] {
         const names = [deriveResourceName(resource.identifier)];
 
         for (const nested of resource.nested ?? []) {
@@ -364,12 +364,12 @@ export class Python extends Writer<PythonGeneratorOptions> {
         return names;
     }
 
-    private shouldImportResourceFamily(resource: RegularTypeSchema): boolean {
+    private shouldImportResourceFamily(resource: SpecializationTypeSchema): boolean {
         return resource.identifier.kind === "resource" && (resource.typeFamily?.resources?.length ?? 0) > 0;
     }
 
     private generateExportsDeclaration(
-        packageComplexTypes: RegularTypeSchema[] | undefined,
+        packageComplexTypes: SpecializationTypeSchema[] | undefined,
         allResourceNames: string[],
     ): void {
         this.squareBlock(["__all__", "="], () => {
@@ -384,7 +384,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         });
     }
 
-    private generateResourceModule(schema: RegularTypeSchema): void {
+    private generateResourceModule(schema: SpecializationTypeSchema): void {
         this.cat(`${snakeCase(schema.identifier.name)}.py`, () => {
             this.generateDisclaimer();
             this.generateDefaultImports(false);
@@ -403,7 +403,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
             this.pyImportFrom(`${this.opts.rootPackageName}.fhirpy_base_model`, "FhirpyBaseModel");
     }
 
-    private generateType(schema: RegularTypeSchema): void {
+    private generateType(schema: SpecializationTypeSchema): void {
         const className = deriveResourceName(schema.identifier);
         const superClasses = this.getSuperClasses(schema);
 
@@ -414,7 +414,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         this.line();
     }
 
-    private getSuperClasses(schema: RegularTypeSchema): string[] {
+    private getSuperClasses(schema: SpecializationTypeSchema): string[] {
         const bases: string[] = [];
         if (schema.base) bases.push(schema.base.name);
         bases.push(...this.injectSuperClasses(schema.identifier.url));
@@ -422,7 +422,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         return bases;
     }
 
-    private generateClassBody(schema: RegularTypeSchema): void {
+    private generateClassBody(schema: SpecializationTypeSchema): void {
         this.generateModelConfig();
 
         if (!schema.fields) {
@@ -446,7 +446,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         this.line(`model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="${extraMode}")`);
     }
 
-    private generateResourceTypeField(schema: RegularTypeSchema): void {
+    private generateResourceTypeField(schema: SpecializationTypeSchema): void {
         const hasChildren = (schema.typeFamily?.resources?.length ?? 0) > 0;
 
         if (hasChildren) {
@@ -467,7 +467,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         this.line(")");
     }
 
-    private generateFields(schema: RegularTypeSchema, schemaName: string): void {
+    private generateFields(schema: SpecializationTypeSchema, schemaName: string): void {
         const sortedFields = Object.entries(schema.fields ?? []).sort(([a], [b]) => a.localeCompare(b));
 
         for (const [fieldName, field] of sortedFields) {
@@ -544,7 +544,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         return ` = Field(${aliasSpec})`;
     }
 
-    private generateResourceMethods(schema: RegularTypeSchema): void {
+    private generateResourceMethods(schema: SpecializationTypeSchema): void {
         const className = schema.identifier.name.toString();
 
         this.line();
@@ -556,7 +556,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         this.line("    return cls.model_validate_json(json)");
     }
 
-    private generateNestedTypes(schema: RegularTypeSchema): void {
+    private generateNestedTypes(schema: SpecializationTypeSchema): void {
         if (!schema.nested) return;
 
         this.line();
@@ -578,7 +578,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         }
     }
 
-    private generateDependenciesImports(schema: RegularTypeSchema): void {
+    private generateDependenciesImports(schema: SpecializationTypeSchema): void {
         if (!schema.dependencies || schema.dependencies.length === 0) return;
 
         this.importComplexTypeDependencies(schema.dependencies);
@@ -650,7 +650,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
         this.pyImportFrom(this.pyPackage(identifier), pascalCase(identifier.name));
     }
 
-    private generateResourceFamilies(packageResources: RegularTypeSchema[]): void {
+    private generateResourceFamilies(packageResources: SpecializationTypeSchema[]): void {
         assert(this.tsIndex !== undefined);
         const packages = //this.helper.getPackages(packageResources, this.opts.rootPackageName);
             Object.keys(groupByPackages(packageResources)).map(

--- a/src/api/writer-generator/typescript/writer.ts
+++ b/src/api/writer-generator/typescript/writer.ts
@@ -15,7 +15,7 @@ import {
     type Name,
     packageMeta,
     packageMetaToFhir,
-    type RegularTypeSchema,
+    type SpecializationTypeSchema,
     type TypeSchema,
 } from "@root/typeschema/types";
 import { groupByPackages, type TypeSchemaIndex } from "@root/typeschema/utils";
@@ -145,7 +145,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         });
     }
 
-    generateDependenciesImports(tsIndex: TypeSchemaIndex, schema: RegularTypeSchema, importPrefix = "../") {
+    generateDependenciesImports(tsIndex: TypeSchemaIndex, schema: SpecializationTypeSchema, importPrefix = "../") {
         if (schema.dependencies) {
             const imports = [];
             const skipped = [];
@@ -191,7 +191,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         }
     }
 
-    generateComplexTypeReexports(schema: RegularTypeSchema) {
+    generateComplexTypeReexports(schema: SpecializationTypeSchema) {
         const complexTypeDeps = schema.dependencies?.filter(isComplexTypeIdentifier);
         if (complexTypeDeps && complexTypeDeps.length > 0) {
             for (const dep of complexTypeDeps) {
@@ -208,7 +208,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         this.lineSM(`${extFieldName}?: ${typeExpr}`);
     }
 
-    generateType(tsIndex: TypeSchemaIndex, schema: RegularTypeSchema) {
+    generateType(tsIndex: TypeSchemaIndex, schema: SpecializationTypeSchema) {
         let name: string;
         // Generic types: Reference, Coding, CodeableConcept
         const genericTypes = ["Reference", "Coding", "CodeableConcept"];
@@ -307,7 +307,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         return false;
     }
 
-    generateResourceTypePredicate(schema: RegularTypeSchema) {
+    generateResourceTypePredicate(schema: SpecializationTypeSchema) {
         if (!isResourceTypeSchema(schema)) return;
         const name = tsResourceName(schema.identifier);
         this.curlyBlock(["export", "const", `is${name}`, "=", `(resource: unknown): resource is ${name}`, "=>"], () => {
@@ -317,7 +317,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         });
     }
 
-    generateNestedTypes(tsIndex: TypeSchemaIndex, schema: RegularTypeSchema) {
+    generateNestedTypes(tsIndex: TypeSchemaIndex, schema: SpecializationTypeSchema) {
         if (schema.nested) {
             for (const subtype of schema.nested) {
                 this.generateType(tsIndex, subtype);

--- a/src/typeschema/ir/tree-shake.ts
+++ b/src/typeschema/ir/tree-shake.ts
@@ -18,7 +18,7 @@ import {
     type NestedType,
     type PkgName,
     type ProfileTypeSchema,
-    type RegularTypeSchema,
+    type SpecializationTypeSchema,
     type TypeSchema,
 } from "../types";
 import type { TypeSchemaIndex } from "../utils";
@@ -78,7 +78,7 @@ export const packageTreeShakeReadme = (report: TypeSchemaIndex | IrReport, pkgNa
     return lines.join("\n");
 };
 
-const mutableSelectFields = (schema: RegularTypeSchema, selectFields: string[]) => {
+const mutableSelectFields = (schema: SpecializationTypeSchema, selectFields: string[]) => {
     const selectedFields: Record<string, Field> = {};
 
     const selectPolimorphic: Record<string, { declaration?: string[]; instances?: string[] }> = {};
@@ -113,7 +113,7 @@ const mutableSelectFields = (schema: RegularTypeSchema, selectFields: string[]) 
     schema.fields = selectedFields;
 };
 
-const mutableIgnoreFields = (schema: RegularTypeSchema, ignoreFields: string[]) => {
+const mutableIgnoreFields = (schema: SpecializationTypeSchema, ignoreFields: string[]) => {
     for (const fieldName of ignoreFields) {
         const field = schema.fields?.[fieldName];
         if (!schema.fields || !field) throw new Error(`Field ${fieldName} not found`);
@@ -207,7 +207,7 @@ export const treeShakeTypeSchema = (schema: TypeSchema, rule: TreeShakeRule, _lo
 
     if (schema.nested) {
         const usedTypes = new Set<CanonicalUrl>();
-        const collectUsedNestedTypes = (s: RegularTypeSchema | NestedType) => {
+        const collectUsedNestedTypes = (s: SpecializationTypeSchema | NestedType) => {
             Object.values(s.fields ?? {})
                 .filter(isNotChoiceDeclarationField)
                 .filter((f) => isNestedIdentifier(f.type))

--- a/src/typeschema/types.ts
+++ b/src/typeschema/types.ts
@@ -146,13 +146,13 @@ export const concatIdentifiers = (...sources: (Identifier[] | undefined)[]): Ide
 };
 
 export type TypeSchema =
-    | RegularTypeSchema
+    | SpecializationTypeSchema
     | PrimitiveTypeSchema
     | ValueSetTypeSchema
     | BindingTypeSchema
     | ProfileTypeSchema;
 
-export const isSpecializationTypeSchema = (schema: TypeSchema | undefined): schema is RegularTypeSchema => {
+export const isSpecializationTypeSchema = (schema: TypeSchema | undefined): schema is SpecializationTypeSchema => {
     return (
         schema?.identifier.kind === "resource" ||
         schema?.identifier.kind === "complex-type" ||
@@ -160,11 +160,11 @@ export const isSpecializationTypeSchema = (schema: TypeSchema | undefined): sche
     );
 };
 
-export const isComplexTypeTypeSchema = (schema: TypeSchema | undefined): schema is RegularTypeSchema => {
+export const isComplexTypeTypeSchema = (schema: TypeSchema | undefined): schema is SpecializationTypeSchema => {
     return schema?.identifier.kind === "complex-type";
 };
 
-export const isResourceTypeSchema = (schema: TypeSchema | undefined): schema is RegularTypeSchema => {
+export const isResourceTypeSchema = (schema: TypeSchema | undefined): schema is SpecializationTypeSchema => {
     return schema?.identifier.kind === "resource";
 };
 
@@ -172,7 +172,7 @@ export const isPrimitiveTypeSchema = (schema: TypeSchema | undefined): schema is
     return schema?.identifier.kind === "primitive-type";
 };
 
-export const isLogicalTypeSchema = (schema: TypeSchema | undefined): schema is RegularTypeSchema => {
+export const isLogicalTypeSchema = (schema: TypeSchema | undefined): schema is SpecializationTypeSchema => {
     return schema?.identifier.kind === "logical";
 };
 
@@ -263,7 +263,7 @@ export const extractExtensionDeps = (ext: ProfileExtension): Identifier[] => [
     ...(ext.subExtensions?.flatMap((sub) => (sub.valueFieldType ? [sub.valueFieldType] : [])) ?? []),
 ];
 
-export interface RegularTypeSchema {
+export interface SpecializationTypeSchema {
     // TODO: restrict to ResourceIdentifier | ComplexTypeIdentifier | LogicalIdentifier
     identifier: Identifier;
     base?: Identifier;

--- a/src/typeschema/utils.ts
+++ b/src/typeschema/utils.ts
@@ -22,7 +22,7 @@ import {
     type PkgName,
     type ProfileExtension,
     type ProfileTypeSchema,
-    type RegularTypeSchema,
+    type SpecializationTypeSchema,
     type TypeSchema,
 } from "./types";
 
@@ -48,8 +48,8 @@ export const groupByPackages = (typeSchemas: TypeSchema[]): Record<PkgName, Type
     return grouped;
 };
 
-const buildDependencyGraph = (schemas: RegularTypeSchema[]): Record<string, string[]> => {
-    const nameToMap: Record<string, RegularTypeSchema> = {};
+const buildDependencyGraph = (schemas: SpecializationTypeSchema[]): Record<string, string[]> => {
+    const nameToMap: Record<string, SpecializationTypeSchema> = {};
     for (const schema of schemas) {
         nameToMap[schema.identifier.name] = schema;
     }
@@ -96,12 +96,12 @@ const topologicalSort = (graph: Record<string, string[]>): string[] => {
     return sorted;
 };
 
-export const sortAsDeclarationSequence = (schemas: RegularTypeSchema[]): RegularTypeSchema[] => {
+export const sortAsDeclarationSequence = (schemas: SpecializationTypeSchema[]): SpecializationTypeSchema[] => {
     const graph = buildDependencyGraph(schemas);
     const sorted = topologicalSort(graph);
     return sorted
         .map((name) => schemas.find((schema) => schema.identifier.name === name))
-        .filter(Boolean) as RegularTypeSchema[];
+        .filter(Boolean) as SpecializationTypeSchema[];
 };
 
 ///////////////////////////////////////////////////////////
@@ -135,7 +135,7 @@ const populateTypeFamily = (schemas: TypeSchema[]): void => {
         if (allChildren.length === 0) continue;
         const resources = allChildren.filter(isResourceIdentifier);
         const complexTypes = allChildren.filter(isComplexTypeIdentifier);
-        const family: NonNullable<RegularTypeSchema["typeFamily"]> = {};
+        const family: NonNullable<SpecializationTypeSchema["typeFamily"]> = {};
         if (resources.length > 0) family.resources = resources;
         if (complexTypes.length > 0) family.complexTypes = complexTypes;
         if (Object.keys(family).length > 0) schema.typeFamily = family;
@@ -150,9 +150,9 @@ export type TypeSchemaIndex = {
     schemas: TypeSchema[];
     schemasByPackage: Record<PkgName, TypeSchema[]>;
     register?: Register;
-    collectComplexTypes: () => RegularTypeSchema[];
-    collectResources: () => RegularTypeSchema[];
-    collectLogicalModels: () => RegularTypeSchema[];
+    collectComplexTypes: () => SpecializationTypeSchema[];
+    collectResources: () => SpecializationTypeSchema[];
+    collectLogicalModels: () => SpecializationTypeSchema[];
     collectProfiles: () => ProfileTypeSchema[];
     resolve: (id: Identifier) => TypeSchema | undefined;
     resolveByUrl: (pkgName: PkgName, url: CanonicalUrl) => TypeSchema | undefined;
@@ -249,7 +249,7 @@ export const mkTypeSchemaIndex = (
         let cur: TypeSchema | undefined = schema;
         while (cur) {
             res.push(cur);
-            const base = (cur as RegularTypeSchema).base;
+            const base = (cur as SpecializationTypeSchema).base;
             if (base === undefined) break;
             const resolved = resolve(base);
             if (!resolved) {
@@ -298,7 +298,7 @@ export const mkTypeSchemaIndex = (
             if (!isChoiceDeclarationField(declField) || declField.excluded) continue;
 
             for (const cSchema of constraintSchemas) {
-                const sFields = (cSchema as RegularTypeSchema).fields;
+                const sFields = (cSchema as SpecializationTypeSchema).fields;
                 if (!sFields) continue;
                 if (sFields[declName] && isChoiceDeclarationField(sFields[declName])) continue;
 
@@ -340,7 +340,7 @@ export const mkTypeSchemaIndex = (
 
         const mergedFields = {} as Record<string, Field>;
         for (const anySchema of constraintSchemas.slice().reverse()) {
-            const schema = anySchema as RegularTypeSchema;
+            const schema = anySchema as SpecializationTypeSchema;
             if (!schema.fields) continue;
 
             for (const [fieldName, fieldConstraints] of Object.entries(schema.fields)) {
@@ -360,7 +360,7 @@ export const mkTypeSchemaIndex = (
         const dependencies = Object.values(
             Object.fromEntries(
                 constraintSchemas
-                    .flatMap((s) => (s as RegularTypeSchema).dependencies ?? [])
+                    .flatMap((s) => (s as SpecializationTypeSchema).dependencies ?? [])
                     .map((dep) => [dep.url, dep]),
             ),
         );

--- a/test/unit/typeschema/ir/tree-shake.test.ts
+++ b/test/unit/typeschema/ir/tree-shake.test.ts
@@ -13,7 +13,7 @@ import type {
     Name,
     ProfileIdentifier,
     ProfileTypeSchema,
-    RegularTypeSchema,
+    SpecializationTypeSchema,
 } from "@root/typeschema/types";
 import { mkIndex, mkR4Register, mkTestLogger, r4Package, r5Package, resolveTs } from "@typeschema-test/utils";
 
@@ -69,7 +69,7 @@ describe("treeShake specific TypeSchema", async () => {
         "http://hl7.org/fhir/StructureDefinition/Patient" as CanonicalUrl,
         logger,
     );
-    const patientOrigin = patientTss[0] as RegularTypeSchema;
+    const patientOrigin = patientTss[0] as SpecializationTypeSchema;
     assert(patientOrigin !== undefined);
 
     it("Original Patient", () => {
@@ -101,7 +101,7 @@ describe("treeShake specific TypeSchema", async () => {
         it("regular field", () => {
             const patient = treeShakeTypeSchema(patientOrigin, {
                 ignoreFields: ["gender"],
-            }) as RegularTypeSchema;
+            }) as SpecializationTypeSchema;
             expect(patientOrigin.fields?.gender).toBeDefined();
             expect(patient.fields?.gender).toBeUndefined();
             expect(JSON.stringify(patient, null, 2)).toMatchSnapshot();
@@ -121,7 +121,7 @@ describe("treeShake specific TypeSchema", async () => {
             it("choice declaration", () => {
                 const patient = treeShakeTypeSchema(patientOrigin, {
                     ignoreFields: ["multipleBirth"],
-                }) as RegularTypeSchema;
+                }) as SpecializationTypeSchema;
                 expect(patient.fields?.multipleBirth).toBeUndefined();
                 expect(patient.fields?.multipleBirthBoolean).toBeUndefined();
                 expect(patient.fields?.multipleBirthInteger).toBeUndefined();
@@ -130,7 +130,7 @@ describe("treeShake specific TypeSchema", async () => {
             it("choice instance", () => {
                 const patient = treeShakeTypeSchema(patientOrigin, {
                     ignoreFields: ["multipleBirthInteger"],
-                }) as RegularTypeSchema;
+                }) as SpecializationTypeSchema;
                 expect(patient.fields?.multipleBirth).toMatchObject({
                     choices: ["multipleBirthBoolean"],
                 });
@@ -142,7 +142,7 @@ describe("treeShake specific TypeSchema", async () => {
             it("all choice instance", () => {
                 const patient = treeShakeTypeSchema(patientOrigin, {
                     ignoreFields: ["multipleBirthBoolean", "multipleBirthInteger"],
-                }) as RegularTypeSchema;
+                }) as SpecializationTypeSchema;
                 expect(patient.fields?.multipleBirth).toBeUndefined();
                 expect(patient.fields?.multipleBirthBoolean).toBeUndefined();
                 expect(patient.fields?.multipleBirthInteger).toBeUndefined();
@@ -161,7 +161,7 @@ describe("treeShake specific TypeSchema", async () => {
             it("empty ignoreFields array", () => {
                 const patient = treeShakeTypeSchema(patientOrigin, {
                     ignoreFields: [],
-                }) as RegularTypeSchema;
+                }) as SpecializationTypeSchema;
                 expect(JSON.stringify(patient, null, 2)).toBe(JSON.stringify(patientOrigin, null, 2));
             });
         });
@@ -171,7 +171,7 @@ describe("treeShake specific TypeSchema", async () => {
         it("regular field", () => {
             const patient = treeShakeTypeSchema(patientOrigin, {
                 selectFields: ["gender"],
-            }) as RegularTypeSchema;
+            }) as SpecializationTypeSchema;
             expect(patient.fields?.gender).toBeDefined();
             expect(patient.fields?.name).toBeUndefined();
             expect(patient.fields?.birthDate).toBeUndefined();
@@ -182,7 +182,7 @@ describe("treeShake specific TypeSchema", async () => {
         it("multiple regular fields", () => {
             const patient = treeShakeTypeSchema(patientOrigin, {
                 selectFields: ["gender", "birthDate", "active"],
-            }) as RegularTypeSchema;
+            }) as SpecializationTypeSchema;
             expect(patient.fields?.gender).toBeDefined();
             expect(patient.fields?.birthDate).toBeDefined();
             expect(patient.fields?.active).toBeDefined();
@@ -206,7 +206,7 @@ describe("treeShake specific TypeSchema", async () => {
             it("choice declaration - get all polimorphic fields", () => {
                 const patient = treeShakeTypeSchema(patientOrigin, {
                     selectFields: ["multipleBirth"],
-                }) as RegularTypeSchema;
+                }) as SpecializationTypeSchema;
 
                 expect(patient.fields?.multipleBirth).toMatchObject({
                     choices: ["multipleBirthBoolean", "multipleBirthInteger"],
@@ -224,7 +224,7 @@ describe("treeShake specific TypeSchema", async () => {
             it("choice instance", () => {
                 const patient = treeShakeTypeSchema(patientOrigin, {
                     selectFields: ["multipleBirthBoolean"],
-                }) as RegularTypeSchema;
+                }) as SpecializationTypeSchema;
 
                 expect(patient.fields?.multipleBirth).toMatchObject({
                     choices: ["multipleBirthBoolean"],
@@ -240,7 +240,7 @@ describe("treeShake specific TypeSchema", async () => {
             it("choice declaration & instance", () => {
                 const patient = treeShakeTypeSchema(patientOrigin, {
                     selectFields: ["multipleBirth", "multipleBirthBoolean"],
-                }) as RegularTypeSchema;
+                }) as SpecializationTypeSchema;
 
                 expect(patient.fields?.multipleBirth).toMatchObject({
                     choices: ["multipleBirthBoolean"],
@@ -258,7 +258,7 @@ describe("treeShake specific TypeSchema", async () => {
             it("empty selectFields array", () => {
                 const patient = treeShakeTypeSchema(patientOrigin, {
                     selectFields: [],
-                }) as RegularTypeSchema;
+                }) as SpecializationTypeSchema;
 
                 expect(patient.fields).toEqual({});
             });

--- a/test/unit/typeschema/r4.test.ts
+++ b/test/unit/typeschema/r4.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { generateTypeSchemas } from "@root/typeschema";
-import type { CanonicalUrl, Name, RegularTypeSchema } from "@root/typeschema/types";
+import type { CanonicalUrl, Name, SpecializationTypeSchema } from "@root/typeschema/types";
 import { mkR4Register, mkTestLogger, r4Package, registerFsAndMkTs } from "@typeschema-test/utils";
 
 describe("TypeSchema R4 generation", async () => {
@@ -12,7 +12,7 @@ describe("TypeSchema R4 generation", async () => {
         if (!profile) {
             throw new Error("Bundle profile not found");
         }
-        const ts = (await registerFsAndMkTs(r4, profile, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(r4, profile, logger))[0] as SpecializationTypeSchema;
         expect(ts?.nested).toHaveLength(5);
         expect(ts).toMatchObject({
             identifier: { kind: "resource", url: "http://hl7.org/fhir/StructureDefinition/Bundle" },
@@ -55,7 +55,7 @@ describe("TypeSchema R4 generation", async () => {
         if (!md) {
             throw new Error("markdown type not found");
         }
-        const ts = (await registerFsAndMkTs(r4, md, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(r4, md, logger))[0] as SpecializationTypeSchema;
         expect(ts).toMatchObject({
             identifier: {
                 kind: "primitive-type",
@@ -78,7 +78,7 @@ describe("TypeSchema R4 generation", async () => {
         if (!parameters) {
             throw new Error("Parameters resource not found");
         }
-        const ts = (await registerFsAndMkTs(r4, parameters, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(r4, parameters, logger))[0] as SpecializationTypeSchema;
         expect(ts.dependencies).toBeDefined();
         expect(ts.dependencies).toContainEqual({
             kind: "primitive-type",

--- a/test/unit/typeschema/transformer.test.ts
+++ b/test/unit/typeschema/transformer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { Name, PackageMeta, RegularField, RegularTypeSchema } from "@typeschema/types";
+import type { Name, PackageMeta, RegularField, SpecializationTypeSchema } from "@typeschema/types";
 import type { PFS } from "@typeschema-test/utils";
 import { mkR4Register, mkTestLogger, registerFsAndMkTs } from "@typeschema-test/utils";
 
@@ -46,7 +46,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.base).toBeDefined();
@@ -83,7 +83,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.identifier.kind).toBe("complex-type");
@@ -104,7 +104,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.base?.name).toBe("Extension" as Name);
@@ -129,7 +129,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.fields?.contact).toBeDefined();
@@ -149,7 +149,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.dependencies).toBeDefined();
@@ -189,7 +189,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.fields?.names?.array).toBe(true);
@@ -210,7 +210,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.fields?.mandatoryField?.required).toBe(true);
@@ -232,7 +232,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.fields?.value).toBeDefined();
@@ -256,7 +256,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result.length).toBeGreaterThanOrEqual(1);
             expect(schema.fields?.status).toBeDefined();
@@ -277,7 +277,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.fields?.subject).toBeDefined();
@@ -292,7 +292,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.identifier.name).toBe("EmptyResource" as Name);
@@ -333,7 +333,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.fields?.type).toBeDefined();
@@ -358,7 +358,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             // Binding schemas are also generated
             expect(result.length).toBeGreaterThanOrEqual(1);
@@ -405,7 +405,7 @@ describe("TypeSchema Transformer Core Logic", async () => {
             };
 
             const result = await registerFsAndMkTs(r4, fhirSchema, logger);
-            const schema = result[0] as RegularTypeSchema;
+            const schema = result[0] as SpecializationTypeSchema;
 
             expect(result).toHaveLength(1);
             expect(schema.fields?.level1).toBeDefined();

--- a/test/unit/typeschema/transformer/ccda.test.ts
+++ b/test/unit/typeschema/transformer/ccda.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { CanonicalUrl, RegularTypeSchema } from "@root/typeschema/types";
+import type { CanonicalUrl, SpecializationTypeSchema } from "@root/typeschema/types";
 import { ccdaPackage, mkCCDARegister, mkTestLogger, registerFsAndMkTs } from "@typeschema-test/utils";
 
 const skipMe = false;
@@ -16,7 +16,7 @@ describe("TypeSchema CCDA generation", async () => {
         if (!resource) {
             throw new Error("workflow-protectiveFactor not found");
         }
-        const ts = (await registerFsAndMkTs(ccda, resource, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(ccda, resource, logger))[0] as SpecializationTypeSchema;
         expect(ts).toMatchObject({
             identifier: {
                 kind: "profile",
@@ -75,7 +75,7 @@ describe("TypeSchema CCDA generation", async () => {
         if (!resource) {
             throw new Error("ON StructureDefinition not found");
         }
-        const ts = (await registerFsAndMkTs(ccda, resource, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(ccda, resource, logger))[0] as SpecializationTypeSchema;
         expect(ts).toMatchObject({
             identifier: {
                 kind: "logical",
@@ -167,7 +167,7 @@ describe("TypeSchema CCDA generation", async () => {
         if (!resource) {
             throw new Error("ehrsrle-auditevent not found");
         }
-        const ts = (await registerFsAndMkTs(ccda, resource, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(ccda, resource, logger))[0] as SpecializationTypeSchema;
         // console.log(JSON.stringify(ts, null, 2));
         // NOTE: problem: canonical manager recomend us to use R5, but we failing on R4 AuditEvent.
         expect(ts).toMatchObject({

--- a/test/unit/typeschema/transformer/r4.test.ts
+++ b/test/unit/typeschema/transformer/r4.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { generateTypeSchemas } from "@root/typeschema";
-import type { CanonicalUrl, Name, RegularTypeSchema } from "@typeschema/types";
+import type { CanonicalUrl, Name, SpecializationTypeSchema } from "@typeschema/types";
 import { mkR4Register, mkTestLogger, r4Package, registerFsAndMkTs } from "@typeschema-test/utils";
 
 describe("TypeSchema R4 generation", async () => {
@@ -12,7 +12,7 @@ describe("TypeSchema R4 generation", async () => {
         if (!profile) {
             throw new Error("Bundle profile not found");
         }
-        const ts = (await registerFsAndMkTs(r4, profile, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(r4, profile, logger))[0] as SpecializationTypeSchema;
         expect(ts?.nested).toHaveLength(5);
         expect(ts).toMatchObject({
             identifier: { kind: "resource", url: "http://hl7.org/fhir/StructureDefinition/Bundle" },
@@ -55,7 +55,7 @@ describe("TypeSchema R4 generation", async () => {
         if (!md) {
             throw new Error("markdown type not found");
         }
-        const ts = (await registerFsAndMkTs(r4, md, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(r4, md, logger))[0] as SpecializationTypeSchema;
         expect(ts).toMatchObject({
             identifier: {
                 kind: "primitive-type",
@@ -78,7 +78,7 @@ describe("TypeSchema R4 generation", async () => {
         if (!parameters) {
             throw new Error("Parameters resource not found");
         }
-        const ts = (await registerFsAndMkTs(r4, parameters, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(r4, parameters, logger))[0] as SpecializationTypeSchema;
         expect(ts.dependencies).toBeDefined();
         expect(ts.dependencies).toContainEqual({
             kind: "primitive-type",

--- a/test/unit/typeschema/transformer/r5.test.ts
+++ b/test/unit/typeschema/transformer/r5.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { CanonicalUrl, RegularTypeSchema } from "@root/typeschema/types";
+import type { CanonicalUrl, SpecializationTypeSchema } from "@root/typeschema/types";
 import { mkR5Register, mkTestLogger, r5Package, registerFsAndMkTs } from "@typeschema-test/utils";
 
 describe("TypeSchema R5 generation", async () => {
@@ -13,7 +13,7 @@ describe("TypeSchema R5 generation", async () => {
         );
         expect(fs).toBeDefined();
         if (!fs) throw new Error("fs is undefined");
-        const ts = (await registerFsAndMkTs(r5, fs, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(r5, fs, logger))[0] as SpecializationTypeSchema;
 
         expect(ts).toMatchObject({
             identifier: {
@@ -77,7 +77,7 @@ describe("TypeSchema R5 generation", async () => {
         const fs = r5.resolveFs(r5Package, "http://hl7.org/fhir/StructureDefinition/Extension" as CanonicalUrl);
         expect(fs).toBeDefined();
         if (!fs) throw new Error("Failed to resolve fs");
-        const ts = (await registerFsAndMkTs(r5, fs, logger))[0] as RegularTypeSchema;
+        const ts = (await registerFsAndMkTs(r5, fs, logger))[0] as SpecializationTypeSchema;
         expect(ts).toMatchObject({
             identifier: {
                 kind: "complex-type",

--- a/test/unit/typeschema/utils.test.ts
+++ b/test/unit/typeschema/utils.test.ts
@@ -5,7 +5,7 @@ import type {
     Name,
     ProfileTypeSchema,
     RegularField,
-    RegularTypeSchema,
+    SpecializationTypeSchema,
 } from "@typeschema/types";
 import { mkTypeSchemaIndex } from "@typeschema/utils";
 
@@ -36,7 +36,7 @@ const booleanType: Identifier = {
 describe("TypeSchema Index", () => {
     describe("hierarchy", () => {
         it("should return a single element hierarchy for a constraint resource", () => {
-            const aSchema: RegularTypeSchema = {
+            const aSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "A" as Name,
                     package: "test",
@@ -46,7 +46,7 @@ describe("TypeSchema Index", () => {
                 },
             };
 
-            const bSchema: RegularTypeSchema = {
+            const bSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "B" as Name,
                     package: "test",
@@ -63,7 +63,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should return single item for types without base", () => {
-            const aSchema: RegularTypeSchema = {
+            const aSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "A" as Name,
                     package: "test",
@@ -80,7 +80,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should handle a schema without a base reference", () => {
-            const bSchema: RegularTypeSchema = {
+            const bSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "B" as Name,
                     package: "test",
@@ -98,7 +98,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should handle multi-level constraint hierarchy", () => {
-            const aSchema: RegularTypeSchema = {
+            const aSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "A" as Name,
                     package: "test",
@@ -108,7 +108,7 @@ describe("TypeSchema Index", () => {
                 },
             };
 
-            const bSchema: RegularTypeSchema = {
+            const bSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "B" as Name,
                     package: "test",
@@ -119,7 +119,7 @@ describe("TypeSchema Index", () => {
                 base: aSchema.identifier,
             };
 
-            const cSchema: RegularTypeSchema = {
+            const cSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "C" as Name,
                     package: "test",
@@ -137,7 +137,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should throw an error when base type cannot be resolved", () => {
-            const bSchema: RegularTypeSchema = {
+            const bSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "B" as Name,
                     package: "test",
@@ -162,7 +162,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should handle packages with different casing", () => {
-            const aSchema: RegularTypeSchema = {
+            const aSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "A" as Name,
                     package: "test",
@@ -172,7 +172,7 @@ describe("TypeSchema Index", () => {
                 },
             };
 
-            const bSchema: RegularTypeSchema = {
+            const bSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "B" as Name,
                     package: "TEST",
@@ -192,7 +192,7 @@ describe("TypeSchema Index", () => {
 
     describe("typeFamily", () => {
         it("should populate typeFamily.resources on resource schemas with children", () => {
-            const resourceSchema: RegularTypeSchema = {
+            const resourceSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Resource" as Name,
                     package: "test",
@@ -201,7 +201,7 @@ describe("TypeSchema Index", () => {
                     url: "http://example.org/StructureDefinition/Resource" as CanonicalUrl,
                 },
             };
-            const domainSchema: RegularTypeSchema = {
+            const domainSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "DomainResource" as Name,
                     package: "test",
@@ -211,7 +211,7 @@ describe("TypeSchema Index", () => {
                 },
                 base: resourceSchema.identifier,
             };
-            const patientSchema: RegularTypeSchema = {
+            const patientSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Patient" as Name,
                     package: "test",
@@ -236,7 +236,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should populate typeFamily.complexTypes on complex-type hierarchies", () => {
-            const elementSchema: RegularTypeSchema = {
+            const elementSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Element" as Name,
                     package: "test",
@@ -245,7 +245,7 @@ describe("TypeSchema Index", () => {
                     url: "http://example.org/StructureDefinition/Element" as CanonicalUrl,
                 },
             };
-            const backboneSchema: RegularTypeSchema = {
+            const backboneSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "BackboneElement" as Name,
                     package: "test",
@@ -266,7 +266,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should populate both resources and complexTypes for mixed hierarchies", () => {
-            const resourceSchema: RegularTypeSchema = {
+            const resourceSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Resource" as Name,
                     package: "test",
@@ -275,7 +275,7 @@ describe("TypeSchema Index", () => {
                     url: "http://example.org/StructureDefinition/Resource" as CanonicalUrl,
                 },
             };
-            const patientSchema: RegularTypeSchema = {
+            const patientSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Patient" as Name,
                     package: "test",
@@ -285,7 +285,7 @@ describe("TypeSchema Index", () => {
                 },
                 base: resourceSchema.identifier,
             };
-            const elementSchema: RegularTypeSchema = {
+            const elementSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Element" as Name,
                     package: "test",
@@ -294,7 +294,7 @@ describe("TypeSchema Index", () => {
                     url: "http://example.org/StructureDefinition/Element" as CanonicalUrl,
                 },
             };
-            const codingSchema: RegularTypeSchema = {
+            const codingSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Coding" as Name,
                     package: "test",
@@ -316,7 +316,7 @@ describe("TypeSchema Index", () => {
 
     describe("flatProfile", () => {
         it("should flatten a profile with a single constraint", () => {
-            const baseSchema: RegularTypeSchema = {
+            const baseSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Base" as Name,
                     package: "test",
@@ -359,7 +359,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should merge fields from multiple constraints", () => {
-            const baseSchema: RegularTypeSchema = {
+            const baseSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Base" as Name,
                     package: "test",
@@ -427,7 +427,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should override fields when merged", () => {
-            const baseSchema: RegularTypeSchema = {
+            const baseSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Base" as Name,
                     package: "test",
@@ -490,7 +490,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should handle constraints without fields", () => {
-            const baseSchema: RegularTypeSchema = {
+            const baseSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Base" as Name,
                     package: "test",
@@ -564,7 +564,7 @@ describe("TypeSchema Index", () => {
         });
 
         it("should preserve identifier from original schema", () => {
-            const baseSchema: RegularTypeSchema = {
+            const baseSchema: SpecializationTypeSchema = {
                 identifier: {
                     name: "Base" as Name,
                     package: "test",


### PR DESCRIPTION
## Summary

- Rename `RegularTypeSchema` → `SpecializationTypeSchema` to match the existing `isSpecializationTypeSchema` type guard
- Pure rename, no logic changes