### PR TITLE
TypeSchema: Remove dead code found by knip

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@atomic-ehr/codegen",
@@ -9,7 +8,6 @@
         "@atomic-ehr/fhirschema": "^0.0.8",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
-        "tinyglobby": "^0.2.15",
         "yaml": "^2.8.2",
         "yargs": "^18.0.0",
       },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@atomic-ehr/fhirschema": "^0.0.8",
     "mustache": "^4.2.0",
     "picocolors": "^1.1.1",
-    "tinyglobby": "^0.2.15",
     "yaml": "^2.8.2",
     "yargs": "^18.0.0"
   },

--- a/src/api/writer-generator/utils.ts
+++ b/src/api/writer-generator/utils.ts
@@ -1,5 +1,3 @@
-import type { TypeSchema } from "@root/typeschema";
-
 export const words = (s: string) => {
     return s.split(/(?<=[a-z])(?=[A-Z])|[-_.\s]/).filter(Boolean);
 };
@@ -63,7 +61,3 @@ export function deepEqual<T>(obj1: T, obj2: T): boolean {
 
     return keys1.every((key) => keys2.includes(key) && deepEqual(obj1[key], obj2[key]));
 }
-
-export const typeSchemaInfo = (schema: TypeSchema): string => {
-    return `<${schema.identifier.url}> from ${schema.identifier.package}#${schema.identifier.version}`;
-};

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -13,15 +13,6 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { typeschemaCommand } from "./typeschema";
 
-/**
- * CLI arguments interface
- */
-export interface CLIArgv {
-    verbose?: boolean;
-    debug?: boolean;
-    logLevel?: LogLevel;
-}
-
 let cliLogger = mkLogger({ prefix: "cli" });
 
 async function setupLoggingMiddleware(argv: any) {

--- a/src/typeschema/types.ts
+++ b/src/typeschema/types.ts
@@ -4,10 +4,8 @@
  */
 
 import { createHash } from "node:crypto";
-import type { CanonicalManager } from "@atomic-ehr/fhir-canonical-manager";
 import type * as FS from "@atomic-ehr/fhirschema";
 import type { StructureDefinition, ValueSet, ValueSetCompose } from "@root/fhir-types/hl7-fhir-r4-core";
-import type { CodegenLog } from "@root/utils/log";
 
 export type Name = string & { readonly __brand: unique symbol };
 export type CanonicalUrl = string & { readonly __brand: unique symbol };
@@ -47,16 +45,6 @@ export const packageMeta = (schema: TypeSchema): PackageMeta => {
 };
 export const packageMetaToFhir = (packageMeta: PackageMeta) => `${packageMeta.name}#${packageMeta.version}`;
 export const packageMetaToNpm = (packageMeta: PackageMeta) => `${packageMeta.name}@${packageMeta.version}`;
-export const fhirToPackageMeta = (fhir: string) => {
-    const [name, version] = fhir.split("#");
-    if (!name) throw new Error(`Invalid FHIR package meta: ${fhir}`);
-    return { name, version: version ?? "latest" };
-};
-export const npmToPackageMeta = (fhir: string) => {
-    const [name, version] = fhir.split("@");
-    if (!name) throw new Error(`Invalid FHIR package meta: ${fhir}`);
-    return { name, version: version ?? "latest" };
-};
 
 export const hashSchema = (schema: TypeSchema): string => {
     const json = JSON.stringify(schema);
@@ -426,11 +414,3 @@ export const enrichValueSet = (vs: ValueSet, packageMeta: PackageMeta): RichValu
 };
 
 ///////////////////////////////////////////////////////////
-
-export interface TypeschemaGeneratorOptions {
-    logger?: CodegenLog;
-    treeshake?: string[];
-    manager: ReturnType<typeof CanonicalManager>;
-    /** Custom FHIR package registry URL */
-    registry?: string;
-}


### PR DESCRIPTION
- Remove unused `fhirToPackageMeta`, `npmToPackageMeta` from `typeschema/types.ts`
- Remove unused `TypeschemaGeneratorOptions` interface from `typeschema/types.ts`
- Remove unused `typeSchemaInfo` from `writer-generator/utils.ts`
- Remove unused `CLIArgv` interface from `cli/commands/index.ts`
- Remove unused `tinyglobby` dependency