### PR TITLE
CI: Rework package-managers job and update deps. Fix work in cjs mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -48,16 +48,43 @@ jobs:
       - name: Run security audit
         run: bun audit
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build and pack
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+          bun pm pack
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v5
+        with:
+          name: package-tarball
+          path: "*.tgz"
+
   package-managers:
     runs-on: ubuntu-latest
+    needs: build
 
     strategy:
+      fail-fast: false
       matrix:
         package-manager: [bun, npm, pnpm]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Download tarball
+        uses: actions/download-artifact@v5
+        with:
+          name: package-tarball
 
       - name: Setup Bun
         if: matrix.package-manager == 'bun'
@@ -67,44 +94,67 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.package-manager != 'bun'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 
       - name: Setup pnpm
         if: matrix.package-manager == 'pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: latest
 
-      - name: Install dependencies (bun)
-        if: matrix.package-manager == 'bun'
-        run: bun install
-
-      - name: Install dependencies (npm)
-        if: matrix.package-manager == 'npm'
-        run: npm install
-
-      - name: Install dependencies (pnpm)
-        if: matrix.package-manager == 'pnpm'
-        run: pnpm install
-
-      - name: Run codegen for FHIR R4
+      - name: Install package
         run: |
+          TARBALL=$(ls *.tgz)
+          mkdir /tmp/test-install && cd /tmp/test-install
+          echo '{}' > package.json
+
           if [ "${{ matrix.package-manager }}" == "bun" ]; then
-            bun run examples/python/generate.ts
+            bun add "$OLDPWD/$TARBALL"
           elif [ "${{ matrix.package-manager }}" == "npm" ]; then
-            npx tsx examples/python/generate.ts
+            npm install "$OLDPWD/$TARBALL"
           else
-            pnpm dlx tsx examples/python/generate.ts
+            pnpm add "$OLDPWD/$TARBALL"
           fi
 
-      - name: Verify output exists
+      - name: Generate FHIR R4 type tree
+        working-directory: /tmp/test-install
         run: |
-          if [ -d examples/python/fhir_types ]; then
-            echo "Output directory generated successfully"
-            ls -la examples/python/fhir_types
+          cat > generate.ts <<'SCRIPT'
+          import { APIBuilder } from "@atomic-ehr/codegen";
+
+          const generate = async () => {
+              const builder = new APIBuilder()
+                  .fromPackage("hl7.fhir.r4.core", "4.0.1")
+                  .introspection({ typeTree: "./type-tree.json" })
+                  .outputTo("./output");
+
+              const report = await builder.generate();
+
+              if (!report.success) {
+                  console.error("Generation failed");
+                  process.exit(1);
+              }
+
+              console.log("OK: type tree generated");
+          };
+
+          generate();
+          SCRIPT
+
+          if [ "${{ matrix.package-manager }}" == "bun" ]; then
+            bun generate.ts
+          elif [ "${{ matrix.package-manager }}" == "npm" ]; then
+            npx tsx generate.ts
           else
-            echo "Output directory not found"
+            pnpm dlx tsx generate.ts
+          fi
+
+      - name: Verify output
+        run: |
+          if [ ! -f /tmp/test-install/output/type-tree.json ]; then
+            echo "type-tree.json not found"
             exit 1
           fi
+          echo "type-tree.json exists ($(wc -c < /tmp/test-install/output/type-tree.json) bytes)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -58,7 +58,7 @@ jobs:
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -77,10 +77,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -96,7 +96,7 @@ jobs:
       - name: Build
         run: bun run build
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -108,7 +108,7 @@ jobs:
         run: npm publish --tag latest --access public
 
       - name: Create Github Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -16,7 +16,7 @@ jobs:
         dotnet-version: [8.0.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -24,7 +24,7 @@ jobs:
           bun-version: ${{ matrix.bun-version }}
 
       - name: Setup .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
@@ -57,10 +57,10 @@ jobs:
         bun-version: [latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -94,7 +94,7 @@ jobs:
         bun-version: [latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -129,10 +129,10 @@ jobs:
         bun-version: [latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -154,7 +154,7 @@ jobs:
         python-version: [ "3.13" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -195,7 +195,7 @@ jobs:
         python-version: [ "3.13" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -236,7 +236,7 @@ jobs:
         java-version: [21, 25]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -244,7 +244,7 @@ jobs:
           bun-version: ${{ matrix.bun-version }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
           distribution: "temurin"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A powerful, extensible code generation toolkit for FHIR ([Fast Healthcare Intero
 | Feature                           | TypeScript | Python  | C#   | Mustache |
 |-----------------------------------|------------|---------|------|----------|
 | Resources & Complex Types         | yes        | yes     | yes  | template |
-| Polymorphic container `Bundle<T>` | yes        | no      | no   | no       |
+| Polymorphic container `Bundle<T>` | yes        | yes     | no   | no       |
 | Value Set Bindings                | inline     | limited | enum | template |
 | Primitive Extensions              | yes        | no      | no   | no       |
 | Profiles                          | yes        | no      | no   | no       |

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@atomic-ehr/codegen",
       "dependencies": {
-        "@atomic-ehr/fhir-canonical-manager": "^0.0.21",
-        "@atomic-ehr/fhirschema": "0.0.10",
+        "@atomic-ehr/fhir-canonical-manager": "0.0.22",
+        "@atomic-ehr/fhirschema": "0.0.11",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
         "yaml": "^2.8.3",
@@ -32,9 +32,9 @@
     "smol-toml": ">=1.6.1",
   },
   "packages": {
-    "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.21", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-MTmPXWixNJ6Wa2b9AqTeo4wg37w9u9ebDnVj0eRDwspDrNHhcgM/XYtEV3Oio7Mnzam3n9m0IPsto8iPQ87ilA=="],
+    "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.22", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-pX+glAxQPKs13AV/ZQgLCsKK9q79kBb1ft2xdt9I8EmuooLwNCHJgDz1xsTEVW6y34b680dtAYAvVKejxtn5dw=="],
 
-    "@atomic-ehr/fhirschema": ["@atomic-ehr/fhirschema@0.0.10", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-7yNkq6VwHFp7CC7KFFfxvi6k2LngfcWhBepS+BqZTNiXdbHurR+5PMbmmgZH3Bm3s11nZayl4ntlSPcjPcPmeA=="],
+    "@atomic-ehr/fhirschema": ["@atomic-ehr/fhirschema@0.0.11", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-oMNxhncEGspGI+QlK/FPjc7akLbfwMYw/hDfW6SbO8xF1KvSSH7NWqc3CJg/k5/309ZuJ6lKsHkgmgVDxo80sQ=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.4", "@biomejs/cli-darwin-x64": "2.4.4", "@biomejs/cli-linux-arm64": "2.4.4", "@biomejs/cli-linux-arm64-musl": "2.4.4", "@biomejs/cli-linux-x64": "2.4.4", "@biomejs/cli-linux-x64-musl": "2.4.4", "@biomejs/cli-win32-arm64": "2.4.4", "@biomejs/cli-win32-x64": "2.4.4" }, "bin": { "biome": "bin/biome" } }, "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q=="],
 

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
   },
   "homepage": "https://github.com/atomic-ehr/codegen#readme",
   "dependencies": {
-    "@atomic-ehr/fhir-canonical-manager": "^0.0.21",
-    "@atomic-ehr/fhirschema": "0.0.10",
+    "@atomic-ehr/fhir-canonical-manager": "0.0.22",
+    "@atomic-ehr/fhirschema": "0.0.11",
     "mustache": "^4.2.0",
     "picocolors": "^1.1.1",
     "yaml": "^2.8.3",


### PR DESCRIPTION
## CI
- Rework `package-managers` job: build once with bun, share tarball via artifact, install + run generate script per PM
  - `bun generate.ts`, `npx tsx generate.ts`, `pnpm dlx tsx generate.ts`
  - Add `fail-fast: false` so all jobs run independently
- Add `build` job that produces and uploads the package tarball
- Update all GitHub Actions to latest major versions across all workflows
  - `actions/checkout` v4 → v5
  - `actions/upload-artifact` v4 → v5, `download-artifact` v4 → v5
  - `actions/setup-node` v4 → v5, `setup-dotnet` v4 → v5, `setup-java` v4 → v5
  - `pnpm/action-setup` v4 → v5
  - `oven-sh/setup-bun` v1 → v2 (release.yml)
  - `softprops/action-gh-release` v2 → v3

## Deps
- `@atomic-ehr/fhirschema` 0.0.10 → 0.0.11 — adds `"default"` export condition + `.js` extensions on validator imports
- `@atomic-ehr/fhir-canonical-manager` ^0.0.21 → 0.0.22 — adds `"default"` export condition