### PR TITLE
PY: Fix to_json to include resourceType

### DIFF
--- a/examples/python/__snapshots__/patient_with_extensions.json
+++ b/examples/python/__snapshots__/patient_with_extensions.json
@@ -1,4 +1,5 @@
 {
+  "resourceType": "Patient",
   "_birthDate": {
     "extension": [
       {

--- a/examples/python/fhir_types/hl7_fhir_r4_core/base.py
+++ b/examples/python/fhir_types/hl7_fhir_r4_core/base.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import Generic, List as PyList, Literal
+from typing import Any, Generic, List as PyList, Literal
 from typing_extensions import TypeVar
 
 T = TypeVar('T', bound=str, default=str)

--- a/examples/python/fhir_types/hl7_fhir_r4_core/bundle.py
+++ b/examples/python/fhir_types/hl7_fhir_r4_core/bundle.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import BackboneElement, Identifier, Signature
 from fhir_types.hl7_fhir_r4_core.resource import Resource
@@ -68,6 +68,9 @@ class Bundle(Resource):
     total_extension: Element | None = Field(None, alias="_total", serialization_alias="_total")
     type: Literal["document", "message", "transaction", "transaction-response", "batch", "batch-response", "history", "searchset", "collection"] = Field(alias="type", serialization_alias="type")
     type_extension: Element | None = Field(None, alias="_type", serialization_alias="_type")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/examples/python/fhir_types/hl7_fhir_r4_core/domain_resource.py
+++ b/examples/python/fhir_types/hl7_fhir_r4_core/domain_resource.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import Extension, Narrative
 from fhir_types.hl7_fhir_r4_core.resource import Resource
@@ -24,6 +24,9 @@ class DomainResource(Resource):
     extension: PyList[Extension] | None = Field(None, alias="extension", serialization_alias="extension")
     modifier_extension: PyList[Extension] | None = Field(None, alias="modifierExtension", serialization_alias="modifierExtension")
     text: Narrative | None = Field(None, alias="text", serialization_alias="text")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/examples/python/fhir_types/hl7_fhir_r4_core/observation.py
+++ b/examples/python/fhir_types/hl7_fhir_r4_core/observation.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import (\
     Annotation, BackboneElement, CodeableConcept, Identifier, Period, Quantity, Range, Ratio, Reference, SampledData, \
@@ -98,6 +98,9 @@ class Observation(DomainResource):
     value_string_extension: Element | None = Field(None, alias="_valueString", serialization_alias="_valueString")
     value_time: str | None = Field(None, alias="valueTime", serialization_alias="valueTime")
     value_time_extension: Element | None = Field(None, alias="_valueTime", serialization_alias="_valueTime")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/examples/python/fhir_types/hl7_fhir_r4_core/operation_outcome.py
+++ b/examples/python/fhir_types/hl7_fhir_r4_core/operation_outcome.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import BackboneElement, CodeableConcept
 from fhir_types.hl7_fhir_r4_core.domain_resource import DomainResource
@@ -31,6 +31,9 @@ class OperationOutcome(DomainResource):
         pattern='OperationOutcome'
     )
     issue: PyList[OperationOutcomeIssue] = Field(alias="issue", serialization_alias="issue")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/examples/python/fhir_types/hl7_fhir_r4_core/patient.py
+++ b/examples/python/fhir_types/hl7_fhir_r4_core/patient.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import (\
     Address, Attachment, BackboneElement, CodeableConcept, ContactPoint, HumanName, Identifier, Period, Reference
@@ -69,6 +69,9 @@ class Patient(DomainResource):
     name: PyList[HumanName] | None = Field(None, alias="name", serialization_alias="name")
     photo: PyList[Attachment] | None = Field(None, alias="photo", serialization_alias="photo")
     telecom: PyList[ContactPoint] | None = Field(None, alias="telecom", serialization_alias="telecom")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/examples/python/fhir_types/hl7_fhir_r4_core/resource.py
+++ b/examples/python/fhir_types/hl7_fhir_r4_core/resource.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import Meta
 from fhir_types.hl7_fhir_r4_core.base import Element
@@ -26,6 +26,9 @@ class Resource(BaseModel):
     language: str | None = Field(None, alias="language", serialization_alias="language")
     language_extension: Element | None = Field(None, alias="_language", serialization_alias="_language")
     meta: Meta | None = Field(None, alias="meta", serialization_alias="meta")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/examples/python/test_sdk.py
+++ b/examples/python/test_sdk.py
@@ -216,3 +216,27 @@ def test_to_from_json() -> None:
     json = p.to_json(indent=2)
     p2 = Patient.from_json(json)
     assert p == p2
+
+
+def test_to_json_shape() -> None:
+    import json as json_mod
+
+    p = Patient(
+        name=[HumanName(given=["Test"], family="Patient")],
+        gender="female",
+        birth_date="1980-01-01",
+    )
+    data = json_mod.loads(p.to_json())
+
+    # Uses FHIR camelCase keys, not Python snake_case; includes resourceType
+    assert data == {
+        "resourceType": "Patient",
+        "name": [{"given": ["Test"], "family": "Patient"}],
+        "gender": "female",
+        "birthDate": "1980-01-01",
+    }
+
+    # Unset fields are omitted
+    assert "id" not in data
+    assert "address" not in data
+    assert "telecom" not in data

--- a/src/api/writer-generator/python.ts
+++ b/src/api/writer-generator/python.ts
@@ -582,6 +582,9 @@ export class Python extends Writer<PythonGeneratorOptions> {
         const className = schema.identifier.name.toString();
 
         this.line();
+        this.line("def model_post_init(self, __context: Any) -> None:");
+        this.line('    self.__pydantic_fields_set__.add("resource_type")');
+        this.line();
         this.line("def to_json(self, indent: int | None = None) -> str:");
         this.line("    return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)");
         this.line();
@@ -602,7 +605,7 @@ export class Python extends Writer<PythonGeneratorOptions> {
     private generateDefaultImports(includeGenericImports: boolean): void {
         this.pyImportFrom("__future__", "annotations");
         this.pyImportFrom("pydantic", "BaseModel", "ConfigDict", "Field", "PositiveInt");
-        const typingImports = ["List as PyList", "Literal"];
+        const typingImports = ["Any", "List as PyList", "Literal"];
         if (includeGenericImports) {
             typingImports.push("Generic");
         }

--- a/test/api/write-generator/__snapshots__/python.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/python.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Python Writer Generator generates Patient resource in inMemoryOnly mode
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import (\\
     Address, Attachment, BackboneElement, CodeableConcept, ContactPoint, HumanName, Identifier, Period, Reference
@@ -64,6 +64,9 @@ class Patient(DomainResource):
     name: PyList[HumanName] | None = Field(None, alias="name", serialization_alias="name")
     photo: PyList[Attachment] | None = Field(None, alias="photo", serialization_alias="photo")
     telecom: PyList[ContactPoint] | None = Field(None, alias="telecom", serialization_alias="telecom")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/test/api/write-generator/multi-package/__snapshots__/cda.test.ts.snap
+++ b/test/api/write-generator/multi-package/__snapshots__/cda.test.ts.snap
@@ -76,7 +76,7 @@ exports[`CDA Python Generation should generate ClinicalDocument type (promoted l
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 
 
@@ -120,6 +120,9 @@ class ClinicalDocument(ANY):
     title: ST | None = Field(None, alias="title", serialization_alias="title")
     type_id: II | None = Field(None, alias="typeId", serialization_alias="typeId")
     version_number: INT | None = Field(None, alias="versionNumber", serialization_alias="versionNumber")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/test/api/write-generator/multi-package/__snapshots__/local-package.test.ts.snap
+++ b/test/api/write-generator/multi-package/__snapshots__/local-package.test.ts.snap
@@ -192,7 +192,7 @@ exports[`Local Package Folder - Multi-Package Generation Python Generation shoul
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import Coding, Identifier, Reference
 from fhir_types.hl7_fhir_r4_core.domain_resource import DomainResource
@@ -214,6 +214,9 @@ class ExampleNotebook(DomainResource):
     tag: PyList[Coding] | None = Field(None, alias="tag", serialization_alias="tag")
     title: str = Field(alias="title", serialization_alias="title")
 
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
+
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)
 
@@ -231,7 +234,7 @@ exports[`Local Package Folder - Multi-Package Generation Python Generation shoul
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import Extension, Narrative
 from fhir_types.hl7_fhir_r4_core.resource import Resource
@@ -252,6 +255,9 @@ class DomainResource(Resource):
     modifier_extension: PyList[Extension] | None = Field(None, alias="modifierExtension", serialization_alias="modifierExtension")
     text: Narrative | None = Field(None, alias="text", serialization_alias="text")
 
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
+
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)
 
@@ -269,7 +275,7 @@ exports[`Local Package Folder - Multi-Package Generation Python Generation shoul
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r4_core.base import (\\
     Address, Attachment, BackboneElement, CodeableConcept, ContactPoint, HumanName, Identifier, Period, Reference
@@ -326,6 +332,9 @@ class Patient(DomainResource):
     name: PyList[HumanName] | None = Field(None, alias="name", serialization_alias="name")
     photo: PyList[Attachment] | None = Field(None, alias="photo", serialization_alias="photo")
     telecom: PyList[ContactPoint] | None = Field(None, alias="telecom", serialization_alias="telecom")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/test/api/write-generator/multi-package/__snapshots__/sql-on-fhir.test.ts.snap
+++ b/test/api/write-generator/multi-package/__snapshots__/sql-on-fhir.test.ts.snap
@@ -86,7 +86,7 @@ exports[`SQL-on-FHIR Python Generation should generate ViewDefinition type (prom
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r5_core.base import BackboneElement
 from fhir_types.hl7_fhir_r5_core.canonical_resource import CanonicalResource
@@ -162,6 +162,9 @@ class ViewDefinition(CanonicalResource):
     select: PyList[ViewDefinitionSelect] = Field(alias="select", serialization_alias="select")
     where: PyList[ViewDefinitionWhere] | None = Field(None, alias="where", serialization_alias="where")
 
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
+
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)
 
@@ -179,7 +182,7 @@ exports[`SQL-on-FHIR Python Generation should generate domain_resource for R5 1`
 
 from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
-from typing import List as PyList, Literal
+from typing import Any, List as PyList, Literal
 
 from fhir_types.hl7_fhir_r5_core.base import Extension, Narrative
 from fhir_types.hl7_fhir_r5_core.resource import Resource
@@ -199,6 +202,9 @@ class DomainResource(Resource):
     extension: PyList[Extension] | None = Field(None, alias="extension", serialization_alias="extension")
     modifier_extension: PyList[Extension] | None = Field(None, alias="modifierExtension", serialization_alias="modifierExtension")
     text: Narrative | None = Field(None, alias="text", serialization_alias="text")
+
+    def model_post_init(self, __context: Any) -> None:
+        self.__pydantic_fields_set__.add("resource_type")
 
     def to_json(self, indent: int | None = None) -> str:
         return self.model_dump_json(exclude_unset=True, exclude_none=True, indent=indent)

--- a/test/api/write-generator/python.test.ts
+++ b/test/api/write-generator/python.test.ts
@@ -34,7 +34,7 @@ describe("Python Writer Generator", async () => {
     });
     it("generates base.py with TypeVar import and declaration", async () => {
         const basePy = result.filesGenerated["generated/hl7_fhir_r4_core/base.py"];
-        expect(basePy).toContain("from typing import Generic, List as PyList, Literal");
+        expect(basePy).toContain("from typing import Any, Generic, List as PyList, Literal");
         expect(basePy).toContain("from typing_extensions import TypeVar");
         expect(basePy).toContain("T = TypeVar('T', bound=str, default=str)");
     });


### PR DESCRIPTION
## Summary

- Add `model_post_init` to generated resource classes that marks `resource_type` as explicitly set, so `exclude_unset=True` no longer strips `resourceType` from `to_json` output
- Add `test_to_json_shape` test verifying the serialized JSON shape uses FHIR camelCase keys and includes `resourceType`
- Update snapshot for `patient_with_extensions.json` to include `resourceType`

**Before:**
```json
{"name": [{"given": ["Test"], "family": "Patient"}], "gender": "female", "birthDate": "1980-01-01"}
```

**After:**
```json
{"resourceType": "Patient", "name": [{"given": ["Test"], "family": "Patient"}], "gender": "female", "birthDate": "1980-01-01"}
```