### PR TITLE
fix(profile): avoid duplicate `meta` key when meta is a factory param

### DIFF
--- a/src/api/writer-generator/typescript/profile.ts
+++ b/src/api/writer-generator/typescript/profile.ts
@@ -488,14 +488,22 @@ const generateFactoryMethods = (
             }
             w.line();
             const extensionVar = extSliceField ? "extensionWithDefaults" : "resolvedExtensions";
+            const hasMetaParam = allFields.some((f) => f.name === "meta");
             w.curlyBlock([`const resource: ${tsBaseResourceName} =`], () => {
                 for (const f of allFields) {
                     if (f.name === "extension") continue;
+                    if (f.name === "meta" && hasMeta) continue;
                     w.line(`${f.name}: ${f.value},`);
                 }
                 w.line(`extension: ${extensionVar},`);
                 if (hasMeta) {
-                    w.line(`meta: { profile: [${profileClassName}.canonicalUrl] },`);
+                    if (hasMetaParam) {
+                        w.line(
+                            `meta: { ...args.meta, profile: [...(args.meta?.profile ?? []), ${profileClassName}.canonicalUrl] },`,
+                        );
+                    } else {
+                        w.line(`meta: { profile: [${profileClassName}.canonicalUrl] },`);
+                    }
                 }
             });
 
@@ -530,12 +538,20 @@ const generateFactoryMethods = (
             if (isPrimitiveIdentifier(flatProfile.base)) {
                 w.lineSM(`const resource = undefined as unknown as ${tsBaseResourceName}`);
             } else {
+                const hasMetaParam = allFields.some((f) => f.name === "meta");
                 w.curlyBlock([`const resource: ${tsBaseResourceName} =`], () => {
                     for (const f of allFields) {
+                        if (f.name === "meta" && hasMeta) continue;
                         w.line(`${f.name}: ${f.value},`);
                     }
                     if (hasMeta) {
-                        w.line(`meta: { profile: [${profileClassName}.canonicalUrl] },`);
+                        if (hasMetaParam) {
+                            w.line(
+                                `meta: { ...args.meta, profile: [...(args.meta?.profile ?? []), ${profileClassName}.canonicalUrl] },`,
+                            );
+                        } else {
+                            w.line(`meta: { profile: [${profileClassName}.canonicalUrl] },`);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Fixes #137.

## Summary

When a profile exposes `meta` as a required factory param (e.g. KBV ITA FOR/ERP profiles where `meta.profile` is pinned via `min: 1`), the generated `createResource` emitted two `meta:` keys in the same object literal — first `meta: args.meta,` from the generic param loop, then `meta: { profile: [canonicalUrl] },` from the unconditional profile emission. This caused `TS1117` and silently dropped caller-supplied `meta.tag` / `meta.source` / extra profile URLs.

## Before / After

**Before** (0.0.10, 0.0.11, 0.0.12 — all broken for profiles with `meta` in Raw type):
```typescript
const resource: Medication = {
    resourceType: "Medication",
    code: args.code,
    id: args.id,
    meta: args.meta,                                          // <-- duplicate
    meta: { profile: [...canonicalUrl] },                     // <-- duplicate
}
```

**After**:
```typescript
const resource: Medication = {
    resourceType: "Medication",
    code: args.code,
    id: args.id,
    meta: { ...args.meta, profile: [...(args.meta?.profile ?? []), ...canonicalUrl] },
}
```

Profiles without `meta` in their Raw type continue to emit the existing single-line form — no behaviour change there.

## Implementation

`src/api/writer-generator/typescript/profile.ts`, both emission branches (Input-helper and standard):

1. Compute `hasMetaParam = allFields.some((f) => f.name === "meta")`.
2. During the field loop, skip `meta` when `hasMeta` is true.
3. When emitting the `meta:` line, if `hasMetaParam`, spread `args.meta` and merge the profile URL into `meta.profile`; otherwise emit the current static form.

## Validation

- `bun test test/unit/` — 174 pass / 4 pre-existing snapshot failures unrelated to this change (same on `main`).
- `bun test test/api/` — 75 pass / 0 fail (no snapshot changes).
- `bun run examples/typescript-r4/generate.ts` — regenerates cleanly, zero diff in example output (none of the example profiles have `meta` in their Raw type, so no emission change).
- Downstream: regenerating a consumer project (mira-adapters, German FHIR profiles) with this fix drops the `tsc --noEmit` error count from 9 → 0 for the duplicate-meta class.

## Notes

- `from()` and `apply()` validation is unaffected because the merged emission still guarantees the profile's `canonicalUrl` is in `meta.profile`.
- Happy to add a regression test fixture (a minimal StructureDefinition that pins `meta.profile` min=1) if you'd like — wanted to ship the minimal fix first.