### PR TITLE
API: group prettyReport files by generator with fileLimit option

### DIFF
--- a/docs/guides/testing-generators.md
+++ b/docs/guides/testing-generators.md
@@ -66,10 +66,11 @@ describe("TypeScript Writer Generator", async () => {
         .generate();
 
     expect(result.success).toBeTrue();
-    expect(Object.keys(result.filesGenerated).length).toEqual(236);
+    const files = result.filesGenerated.typescript!;
+    expect(Object.keys(files).length).toEqual(236);
 
     it("generates Patient resource with snapshot", async () => {
-        expect(result.filesGenerated["generated/types/hl7-fhir-r4-core/Patient.ts"])
+        expect(files["generated/types/hl7-fhir-r4-core/Patient.ts"])
             .toMatchSnapshot();
     });
 });
@@ -84,13 +85,13 @@ describe("TypeScript Writer Generator", async () => {
 
 **Generation Result:**
 - Contains `success` boolean flag
-- Contains `filesGenerated` object with paths as keys and content as values
+- Contains `filesGenerated` nested by generator name, then by path: `filesGenerated[generator][path] = content`
 - Can be accessed and asserted in tests
 
 **Assertions:**
 - Validate success: `expect(result.success).toBeTrue()`
-- Check file count: `expect(Object.keys(result.filesGenerated).length).toEqual(expected)`
-- Snapshot specific files: `expect(result.filesGenerated[path]).toMatchSnapshot()`
+- Check file count for a generator: `expect(Object.keys(result.filesGenerated.typescript!).length).toEqual(expected)`
+- Snapshot specific files: `expect(result.filesGenerated.typescript![path]).toMatchSnapshot()`
 
 ## Configuration Notes
 
@@ -147,7 +148,7 @@ This updates all snapshot files to match current output.
    ```typescript
    it("generates fields with camelCase names", async () => {
        // Changed from PascalCase to camelCase to match TypeScript conventions
-       expect(result.filesGenerated["generated/types/Patient.ts"])
+       expect(result.filesGenerated.typescript!["generated/types/Patient.ts"])
            .toMatchSnapshot();
    });
    ```

--- a/src/api/builder.ts
+++ b/src/api/builder.ts
@@ -63,7 +63,11 @@ function countLinesByMatches(text: string): number {
     return m ? m.length + 1 : 1;
 }
 
-const formatLoc = (loc: number): string => (loc >= 1000 ? `${Math.round(loc / 1000)} kloc` : `${loc} loc`);
+const formatLoc = (loc: number): string => {
+    if (loc >= 10000) return `${Math.round(loc / 1000)} kloc`;
+    if (loc >= 1000) return `${(loc / 1000).toFixed(1)} kloc`;
+    return `${loc} loc`;
+};
 
 export interface PrettyReportOptions {
     /** When a generator produces more than this many files, aggregate them by directory instead of listing each file. */

--- a/src/api/builder.ts
+++ b/src/api/builder.ts
@@ -50,8 +50,8 @@ export interface APIBuilderOptions {
 export type GenerationReport = {
     success: boolean;
     outputDir: string;
-    filesGenerated: Record<string, string>;
-    filesByGenerator: Record<string, string[]>;
+    /** Generated files nested by generator name, then by path: `filesGenerated[generator][path] = content`. */
+    filesGenerated: Record<string, Record<string, string>>;
     errors: string[];
     warnings: string[];
     duration: number;
@@ -75,62 +75,54 @@ export interface PrettyReportOptions {
 }
 
 export const prettyReport = (report: GenerationReport, options: PrettyReportOptions = {}): string => {
-    const { success, filesGenerated, filesByGenerator, errors, warnings, duration } = report;
+    const { success, filesGenerated, errors, warnings, duration } = report;
     const fileLimit = options.fileLimit ?? 20;
     const errorsStr = errors.length > 0 ? `Errors: ${errors.join(", ")}` : undefined;
     const warningsStr = warnings.length > 0 ? `Warnings: ${warnings.join(", ")}` : undefined;
 
-    const locByPath: Record<string, number> = {};
+    let totalFiles = 0;
     let totalLoc = 0;
-    for (const [path, content] of Object.entries(filesGenerated)) {
-        const loc = countLinesByMatches(content);
-        locByPath[path] = loc;
-        totalLoc += loc;
-    }
 
-    const groupedPaths = new Set<string>();
-    const groups = Object.entries(filesByGenerator).map(([name, paths]) => {
-        let groupLoc = 0;
-        for (const p of paths) {
-            groupLoc += locByPath[p] ?? 0;
-            groupedPaths.add(p);
-        }
-        return { name, paths, loc: groupLoc };
-    });
-
-    const ungrouped = Object.keys(filesGenerated).filter((p) => !groupedPaths.has(p));
-    if (ungrouped.length > 0) {
-        const loc = ungrouped.reduce((acc, p) => acc + (locByPath[p] ?? 0), 0);
-        groups.push({ name: "other", paths: ungrouped, loc });
-    }
-
-    const aggregateByDir = (paths: string[]): { dir: string; count: number; loc: number }[] => {
+    const aggregateByDir = (files: Record<string, number>): { dir: string; count: number; loc: number }[] => {
         const byDir: Record<string, { count: number; loc: number }> = {};
-        for (const p of paths) {
+        for (const [p, loc] of Object.entries(files)) {
             const dir = Path.dirname(p);
             byDir[dir] ??= { count: 0, loc: 0 };
             byDir[dir].count += 1;
-            byDir[dir].loc += locByPath[p] ?? 0;
+            byDir[dir].loc += loc;
         }
         return Object.entries(byDir)
             .map(([dir, v]) => ({ dir, count: v.count, loc: v.loc }))
             .sort((a, b) => a.dir.localeCompare(b.dir));
     };
 
-    const groupStrs = groups.map(({ name, paths, loc }) => {
-        const header = `  ${name} (${paths.length} files, ${formatLoc(loc)}):`;
-        if (paths.length === 0) return header;
-        if (paths.length > fileLimit) {
-            const dirs = aggregateByDir(paths);
+    const groupStrs = Object.entries(filesGenerated).map(([name, files]) => {
+        const locByPath: Record<string, number> = {};
+        let groupLoc = 0;
+        for (const [path, content] of Object.entries(files)) {
+            const loc = countLinesByMatches(content);
+            locByPath[path] = loc;
+            groupLoc += loc;
+        }
+        const count = Object.keys(files).length;
+        totalFiles += count;
+        totalLoc += groupLoc;
+
+        const header = `  ${name} (${count} files, ${formatLoc(groupLoc)}):`;
+        if (count === 0) return header;
+        if (count > fileLimit) {
+            const dirs = aggregateByDir(locByPath);
             const dirLines = dirs.map((d) => `    - ${d.dir}/ (${d.count} files, ${formatLoc(d.loc)})`).join("\n");
             return `${header}\n${dirLines}`;
         }
-        const fileLines = paths.map((p) => `    - ${p} (${locByPath[p] ?? 0} loc)`).join("\n");
+        const fileLines = Object.entries(locByPath)
+            .map(([p, loc]) => `    - ${p} (${loc} loc)`)
+            .join("\n");
         return `${header}\n${fileLines}`;
     });
 
     return [
-        `Generated files (${Object.keys(filesGenerated).length} files, ${formatLoc(totalLoc)}):`,
+        `Generated files (${totalFiles} files, ${formatLoc(totalLoc)}):`,
         ...groupStrs,
         errorsStr,
         warningsStr,
@@ -438,7 +430,6 @@ export class APIBuilder {
             success: false,
             outputDir: this.options.outputDir,
             filesGenerated: {},
-            filesByGenerator: {},
             errors: [],
             warnings: [],
             duration: 0,
@@ -503,7 +494,8 @@ export class APIBuilder {
 
             result.success = result.errors.length === 0;
 
-            this.logger.debug(`Generation completed: ${result.filesGenerated.length} files`);
+            const totalFiles = Object.values(result.filesGenerated).reduce((n, f) => n + Object.keys(f).length, 0);
+            this.logger.debug(`Generation completed: ${totalFiles} files`);
         } catch (error) {
             this.logger.error(`Code generation failed: ${error instanceof Error ? error.message : String(error)}`);
             result.errors.push(error instanceof Error ? error.message : String(error));
@@ -539,12 +531,10 @@ export class APIBuilder {
             try {
                 await gen.writer.generateAsync(tsIndex);
                 const fileBuffer: FileBuffer[] = gen.writer.writtenFiles();
-                const paths: string[] = [];
+                const files = (result.filesGenerated[gen.name] ??= {});
                 fileBuffer.forEach((buf) => {
-                    result.filesGenerated[buf.relPath] = buf.content;
-                    paths.push(buf.relPath);
+                    files[buf.relPath] = buf.content;
                 });
-                result.filesByGenerator[gen.name] = paths;
                 this.logger.info(`Generating ${gen.name} finished successfully`);
             } catch (error) {
                 result.errors.push(

--- a/src/api/builder.ts
+++ b/src/api/builder.ts
@@ -65,8 +65,14 @@ function countLinesByMatches(text: string): number {
 
 const formatLoc = (loc: number): string => (loc >= 1000 ? `${Math.round(loc / 1000)} kloc` : `${loc} loc`);
 
-export const prettyReport = (report: GenerationReport): string => {
+export interface PrettyReportOptions {
+    /** When a generator produces more than this many files, aggregate them by directory instead of listing each file. */
+    fileLimit?: number;
+}
+
+export const prettyReport = (report: GenerationReport, options: PrettyReportOptions = {}): string => {
     const { success, filesGenerated, filesByGenerator, errors, warnings, duration } = report;
+    const fileLimit = options.fileLimit ?? 20;
     const errorsStr = errors.length > 0 ? `Errors: ${errors.join(", ")}` : undefined;
     const warningsStr = warnings.length > 0 ? `Warnings: ${warnings.join(", ")}` : undefined;
 
@@ -94,10 +100,29 @@ export const prettyReport = (report: GenerationReport): string => {
         groups.push({ name: "other", paths: ungrouped, loc });
     }
 
+    const aggregateByDir = (paths: string[]): { dir: string; count: number; loc: number }[] => {
+        const byDir: Record<string, { count: number; loc: number }> = {};
+        for (const p of paths) {
+            const dir = Path.dirname(p);
+            byDir[dir] ??= { count: 0, loc: 0 };
+            byDir[dir].count += 1;
+            byDir[dir].loc += locByPath[p] ?? 0;
+        }
+        return Object.entries(byDir)
+            .map(([dir, v]) => ({ dir, count: v.count, loc: v.loc }))
+            .sort((a, b) => a.dir.localeCompare(b.dir));
+    };
+
     const groupStrs = groups.map(({ name, paths, loc }) => {
         const header = `  ${name} (${paths.length} files, ${formatLoc(loc)}):`;
+        if (paths.length === 0) return header;
+        if (paths.length > fileLimit) {
+            const dirs = aggregateByDir(paths);
+            const dirLines = dirs.map((d) => `    - ${d.dir}/ (${d.count} files, ${formatLoc(d.loc)})`).join("\n");
+            return `${header}\n${dirLines}`;
+        }
         const fileLines = paths.map((p) => `    - ${p} (${locByPath[p] ?? 0} loc)`).join("\n");
-        return fileLines ? `${header}\n${fileLines}` : header;
+        return `${header}\n${fileLines}`;
     });
 
     return [

--- a/src/api/builder.ts
+++ b/src/api/builder.ts
@@ -51,6 +51,7 @@ export type GenerationReport = {
     success: boolean;
     outputDir: string;
     filesGenerated: Record<string, string>;
+    filesByGenerator: Record<string, string[]>;
     errors: string[];
     warnings: string[];
     duration: number;
@@ -62,21 +63,46 @@ function countLinesByMatches(text: string): number {
     return m ? m.length + 1 : 1;
 }
 
+const formatLoc = (loc: number): string => (loc >= 1000 ? `${Math.round(loc / 1000)} kloc` : `${loc} loc`);
+
 export const prettyReport = (report: GenerationReport): string => {
-    const { success, filesGenerated, errors, warnings, duration } = report;
+    const { success, filesGenerated, filesByGenerator, errors, warnings, duration } = report;
     const errorsStr = errors.length > 0 ? `Errors: ${errors.join(", ")}` : undefined;
     const warningsStr = warnings.length > 0 ? `Warnings: ${warnings.join(", ")}` : undefined;
-    let allLoc = 0;
-    const files = Object.entries(filesGenerated)
-        .map(([path, content]) => {
-            const loc = countLinesByMatches(content);
-            allLoc += loc;
-            return `  - ${path} (${loc} loc)`;
-        })
-        .join("\n");
+
+    const locByPath: Record<string, number> = {};
+    let totalLoc = 0;
+    for (const [path, content] of Object.entries(filesGenerated)) {
+        const loc = countLinesByMatches(content);
+        locByPath[path] = loc;
+        totalLoc += loc;
+    }
+
+    const groupedPaths = new Set<string>();
+    const groups = Object.entries(filesByGenerator).map(([name, paths]) => {
+        let groupLoc = 0;
+        for (const p of paths) {
+            groupLoc += locByPath[p] ?? 0;
+            groupedPaths.add(p);
+        }
+        return { name, paths, loc: groupLoc };
+    });
+
+    const ungrouped = Object.keys(filesGenerated).filter((p) => !groupedPaths.has(p));
+    if (ungrouped.length > 0) {
+        const loc = ungrouped.reduce((acc, p) => acc + (locByPath[p] ?? 0), 0);
+        groups.push({ name: "other", paths: ungrouped, loc });
+    }
+
+    const groupStrs = groups.map(({ name, paths, loc }) => {
+        const header = `  ${name} (${paths.length} files, ${formatLoc(loc)}):`;
+        const fileLines = paths.map((p) => `    - ${p} (${locByPath[p] ?? 0} loc)`).join("\n");
+        return fileLines ? `${header}\n${fileLines}` : header;
+    });
+
     return [
-        `Generated files (${Math.round(allLoc / 1000)} kloc):`,
-        files,
+        `Generated files (${Object.keys(filesGenerated).length} files, ${formatLoc(totalLoc)}):`,
+        ...groupStrs,
         errorsStr,
         warningsStr,
         `Duration: ${Math.round(duration)}ms`,
@@ -383,6 +409,7 @@ export class APIBuilder {
             success: false,
             outputDir: this.options.outputDir,
             filesGenerated: {},
+            filesByGenerator: {},
             errors: [],
             warnings: [],
             duration: 0,
@@ -483,9 +510,12 @@ export class APIBuilder {
             try {
                 await gen.writer.generateAsync(tsIndex);
                 const fileBuffer: FileBuffer[] = gen.writer.writtenFiles();
+                const paths: string[] = [];
                 fileBuffer.forEach((buf) => {
                     result.filesGenerated[buf.relPath] = buf.content;
+                    paths.push(buf.relPath);
                 });
+                result.filesByGenerator[gen.name] = paths;
                 this.logger.info(`Generating ${gen.name} finished successfully`);
             } catch (error) {
                 result.errors.push(

--- a/test/api/mustache.test.ts
+++ b/test/api/mustache.test.ts
@@ -15,10 +15,11 @@ describe("Mustache Template Based Generation", async () => {
         .throwException()
         .generate();
     expect(report.success).toBeTrue();
-    expect(Object.keys(report.filesGenerated).length).toEqual(192);
+    const files = report.filesGenerated["mustache[./examples/mustache/java]"]!;
+    expect(Object.keys(files).length).toEqual(192);
     it("Patient resource", async () => {
         expect(
-            report.filesGenerated["generated/model/src/main/java/de/solutio/fhir/models/resources/PatientDTO.java"],
+            files["generated/model/src/main/java/de/solutio/fhir/models/resources/PatientDTO.java"],
         ).toMatchSnapshot();
     });
 });

--- a/test/api/write-generator/csharp.test.ts
+++ b/test/api/write-generator/csharp.test.ts
@@ -10,12 +10,13 @@ describe("C# Writer Generator", async () => {
         .throwException()
         .generate();
     expect(result.success).toBeTrue();
-    expect(Object.keys(result.filesGenerated).length).toEqual(154);
+    const files = result.filesGenerated.csharp!;
+    expect(Object.keys(files).length).toEqual(154);
     it("generates Patient resource in inMemoryOnly mode with snapshot", async () => {
-        expect(result.filesGenerated["generated/types/Hl7FhirR4Core/Patient.cs"]).toMatchSnapshot();
+        expect(files["generated/types/Hl7FhirR4Core/Patient.cs"]).toMatchSnapshot();
     });
     it("static files", async () => {
-        expect(result.filesGenerated["generated/types/Client.cs"]).toMatchSnapshot();
-        expect(result.filesGenerated["generated/types/Helper.cs"]).toMatchSnapshot();
+        expect(files["generated/types/Client.cs"]).toMatchSnapshot();
+        expect(files["generated/types/Helper.cs"]).toMatchSnapshot();
     });
 });

--- a/test/api/write-generator/introspection.test.ts
+++ b/test/api/write-generator/introspection.test.ts
@@ -10,18 +10,19 @@ describe("IntrospectionWriter - Fhir Schema Output", async () => {
 
     expect(result.success).toBeTrue();
 
-    expect(Object.keys(result.filesGenerated).length).toEqual(656);
+    const files = result.filesGenerated.introspection!;
+    expect(Object.keys(files).length).toEqual(656);
     it("Generated file list", () => {
-        expect(Object.keys(result.filesGenerated)).toMatchSnapshot();
+        expect(Object.keys(files)).toMatchSnapshot();
     });
     it("Check OperationOutcome introspection schema", () => {
         const operationOutcome =
-            result.filesGenerated["generated/introspection/hl7.fhir.r4.core/OperationOutcome(OperationOutcome).json"];
+            files["generated/introspection/hl7.fhir.r4.core/OperationOutcome(OperationOutcome).json"];
         expect(operationOutcome).toBeDefined();
         expect(operationOutcome).toMatchSnapshot();
     });
     it("Check all introspection data in a single ndjson file", () => {
-        expect(result.filesGenerated["generated/introspection.ndjson"]).toMatchSnapshot();
+        expect(files["generated/introspection.ndjson"]).toMatchSnapshot();
     });
 });
 
@@ -49,18 +50,19 @@ describe("IntrospectionWriter - TypeSchema output", async () => {
 
     expect(result.success).toBeTrue();
 
-    expect(Object.keys(result.filesGenerated).length).toEqual(45);
+    const files = result.filesGenerated.introspection!;
+    expect(Object.keys(files).length).toEqual(44);
     it("Generated file list", () => {
-        expect(Object.keys(result.filesGenerated)).toMatchSnapshot();
+        expect(Object.keys(files)).toMatchSnapshot();
     });
     it("Check OperationOutcome introspection schema", () => {
         const operationOutcome =
-            result.filesGenerated["generated/introspection/hl7.fhir.r4.core/OperationOutcome(OperationOutcome).json"];
+            files["generated/introspection/hl7.fhir.r4.core/OperationOutcome(OperationOutcome).json"];
         expect(operationOutcome).toBeDefined();
         expect(operationOutcome).toMatchSnapshot();
     });
     it("Check all introspection data in a single ndjson file", () => {
-        expect(result.filesGenerated["generated/introspection.ndjson"]).toMatchSnapshot();
+        expect(files["generated/introspection.ndjson"]).toMatchSnapshot();
     });
 });
 
@@ -84,8 +86,10 @@ describe("IntrospectionWriter - typeTree", async () => {
 
     expect(result.success).toBeTrue();
 
+    const files = result.filesGenerated.introspection!;
+
     it("Type tree file should be generated", () => {
-        expect(result.filesGenerated["generated/type-tree.json"]).toBeDefined();
+        expect(files["generated/type-tree.json"]).toBeDefined();
     });
 });
 
@@ -113,18 +117,18 @@ describe("IntrospectionWriter - StructureDefinition output", async () => {
 
     expect(result.success).toBeTrue();
 
+    const files = result.filesGenerated.introspection!;
+
     it("Generated file list", () => {
-        expect(Object.keys(result.filesGenerated)).toMatchSnapshot();
+        expect(Object.keys(files)).toMatchSnapshot();
     });
     it("Check OperationOutcome StructureDefinition", () => {
         const operationOutcome =
-            result.filesGenerated[
-                "generated/structure-definitions/hl7.fhir.r4.core/OperationOutcome(OperationOutcome).json"
-            ];
+            files["generated/structure-definitions/hl7.fhir.r4.core/OperationOutcome(OperationOutcome).json"];
         expect(operationOutcome).toBeDefined();
         expect(operationOutcome).toMatchSnapshot();
     });
     it("Check all StructureDefinitions in a single ndjson file", () => {
-        expect(result.filesGenerated["generated/structure-definitions.ndjson"]).toMatchSnapshot();
+        expect(files["generated/structure-definitions.ndjson"]).toMatchSnapshot();
     });
 });

--- a/test/api/write-generator/multi-package/cda.test.ts
+++ b/test/api/write-generator/multi-package/cda.test.ts
@@ -30,13 +30,14 @@ describe("CDA", async () => {
         });
 
         it("should generate ClinicalDocument type", () => {
-            const clinicalDoc = result.filesGenerated["generated/types/hl7-cda-uv-core/ClinicalDocument.ts"];
+            const clinicalDoc =
+                result.filesGenerated.typescript!["generated/types/hl7-cda-uv-core/ClinicalDocument.ts"];
             expect(clinicalDoc).toBeDefined();
             expect(clinicalDoc).toMatchSnapshot();
         });
 
         it("should generate CDA-specific types", () => {
-            const files = Object.keys(result.filesGenerated);
+            const files = Object.keys(result.filesGenerated.typescript!);
             const cdaFiles = files.filter((f) => f.includes("hl7-cda-uv-core"));
             expect(cdaFiles.length).toBe(124);
 
@@ -56,14 +57,14 @@ describe("CDA", async () => {
         });
 
         it("should generate ClinicalDocument type (promoted logical)", () => {
-            const clinicalDoc = result.filesGenerated["generated/hl7_cda_uv_core/clinical_document.py"];
+            const clinicalDoc = result.filesGenerated.python!["generated/hl7_cda_uv_core/clinical_document.py"];
             expect(clinicalDoc).toBeDefined();
             expect(clinicalDoc).toMatchSnapshot();
         });
 
         it("should generate base package structure", () => {
-            expect(result.filesGenerated["generated/__init__.py"]).toBeDefined();
-            expect(result.filesGenerated["generated/requirements.txt"]).toBeDefined();
+            expect(result.filesGenerated.python!["generated/__init__.py"]).toBeDefined();
+            expect(result.filesGenerated.python!["generated/requirements.txt"]).toBeDefined();
         });
     });
 
@@ -79,14 +80,14 @@ describe("CDA", async () => {
         });
 
         it("should generate ClinicalDocument type (promoted logical)", () => {
-            const clinicalDoc = result.filesGenerated["generated/types/Hl7CdaUvCore/ClinicalDocument.cs"];
+            const clinicalDoc = result.filesGenerated.csharp!["generated/types/Hl7CdaUvCore/ClinicalDocument.cs"];
             expect(clinicalDoc).toBeDefined();
             expect(clinicalDoc).toMatchSnapshot();
         });
 
         it("should generate base helper files", () => {
-            expect(result.filesGenerated["generated/types/base.cs"]).toBeDefined();
-            expect(result.filesGenerated["generated/types/Helper.cs"]).toBeDefined();
+            expect(result.filesGenerated.csharp!["generated/types/base.cs"]).toBeDefined();
+            expect(result.filesGenerated.csharp!["generated/types/Helper.cs"]).toBeDefined();
         });
     });
 });

--- a/test/api/write-generator/multi-package/local-package.test.ts
+++ b/test/api/write-generator/multi-package/local-package.test.ts
@@ -41,22 +41,24 @@ describe("Local Package Folder - Multi-Package Generation", async () => {
         });
 
         it("should generate ExampleNotebook type in custom package folder", () => {
-            const notebookFile = result.filesGenerated["generated/types/example-folder-structures/ExampleNotebook.ts"];
+            const notebookFile =
+                result.filesGenerated.typescript!["generated/types/example-folder-structures/ExampleNotebook.ts"];
             expect(notebookFile).toBeDefined();
             expect(notebookFile).toMatchSnapshot();
         });
 
         it("should resolve R4 dependencies (Identifier, Reference, Coding)", () => {
-            const notebookFile = result.filesGenerated["generated/types/example-folder-structures/ExampleNotebook.ts"];
+            const notebookFile =
+                result.filesGenerated.typescript!["generated/types/example-folder-structures/ExampleNotebook.ts"];
             expect(notebookFile).toContain("Identifier");
             expect(notebookFile).toContain("Reference");
             expect(notebookFile).toContain("Coding");
         });
 
         it("should generate R4 dependency types", () => {
-            expect(result.filesGenerated["generated/types/hl7-fhir-r4-core/Identifier.ts"]).toBeDefined();
-            expect(result.filesGenerated["generated/types/hl7-fhir-r4-core/Reference.ts"]).toBeDefined();
-            expect(result.filesGenerated["generated/types/hl7-fhir-r4-core/Coding.ts"]).toBeDefined();
+            expect(result.filesGenerated.typescript!["generated/types/hl7-fhir-r4-core/Identifier.ts"]).toBeDefined();
+            expect(result.filesGenerated.typescript!["generated/types/hl7-fhir-r4-core/Reference.ts"]).toBeDefined();
+            expect(result.filesGenerated.typescript!["generated/types/hl7-fhir-r4-core/Coding.ts"]).toBeDefined();
         });
     });
 
@@ -83,7 +85,7 @@ describe("Local Package Folder - Multi-Package Generation", async () => {
 
         it("should generate ExampleTypedBundle profile with type-discriminated slices", () => {
             const profileFile =
-                result.filesGenerated[
+                result.filesGenerated.typescript![
                     "generated/types/example-folder-structures/profiles/Bundle_ExampleTypedBundle.ts"
                 ];
             expect(profileFile).toBeDefined();
@@ -103,25 +105,25 @@ describe("Local Package Folder - Multi-Package Generation", async () => {
         });
 
         it("should generate ExampleNotebook type (promoted logical)", () => {
-            const notebook = result.filesGenerated["generated/example_folder_structures/example_notebook.py"];
+            const notebook = result.filesGenerated.python!["generated/example_folder_structures/example_notebook.py"];
             expect(notebook).toBeDefined();
             expect(notebook).toMatchSnapshot();
         });
 
         it("should generate R4 dependency types", () => {
             // Python generator resolves R4 dependencies from tree-shaking
-            expect(result.filesGenerated["generated/hl7_fhir_r4_core/__init__.py"]).toBeDefined();
-            expect(result.filesGenerated["generated/hl7_fhir_r4_core/domain_resource.py"]).toBeDefined();
+            expect(result.filesGenerated.python!["generated/hl7_fhir_r4_core/__init__.py"]).toBeDefined();
+            expect(result.filesGenerated.python!["generated/hl7_fhir_r4_core/domain_resource.py"]).toBeDefined();
         });
 
         it("should generate base types for dependencies", () => {
-            const domainResource = result.filesGenerated["generated/hl7_fhir_r4_core/domain_resource.py"];
+            const domainResource = result.filesGenerated.python!["generated/hl7_fhir_r4_core/domain_resource.py"];
             expect(domainResource).toBeDefined();
             expect(domainResource).toMatchSnapshot();
         });
 
         it("should generate Patient resource", () => {
-            const patient = result.filesGenerated["generated/hl7_fhir_r4_core/patient.py"];
+            const patient = result.filesGenerated.python!["generated/hl7_fhir_r4_core/patient.py"];
             expect(patient).toBeDefined();
             expect(patient).toMatchSnapshot();
         });
@@ -139,31 +141,32 @@ describe("Local Package Folder - Multi-Package Generation", async () => {
         });
 
         it("should generate ExampleNotebook type (promoted logical)", () => {
-            const notebook = result.filesGenerated["generated/types/ExampleFolderStructures/ExampleNotebook.cs"];
+            const notebook =
+                result.filesGenerated.csharp!["generated/types/ExampleFolderStructures/ExampleNotebook.cs"];
             expect(notebook).toBeDefined();
             expect(notebook).toMatchSnapshot();
         });
 
         it("should generate R4 dependency types", () => {
             // C# generator resolves R4 dependencies from tree-shaking
-            expect(result.filesGenerated["generated/types/Hl7FhirR4Core/DomainResource.cs"]).toBeDefined();
-            expect(result.filesGenerated["generated/types/Hl7FhirR4Core/Resource.cs"]).toBeDefined();
+            expect(result.filesGenerated.csharp!["generated/types/Hl7FhirR4Core/DomainResource.cs"]).toBeDefined();
+            expect(result.filesGenerated.csharp!["generated/types/Hl7FhirR4Core/Resource.cs"]).toBeDefined();
         });
 
         it("should generate DomainResource base class", () => {
-            const domainResource = result.filesGenerated["generated/types/Hl7FhirR4Core/DomainResource.cs"];
+            const domainResource = result.filesGenerated.csharp!["generated/types/Hl7FhirR4Core/DomainResource.cs"];
             expect(domainResource).toBeDefined();
             expect(domainResource).toMatchSnapshot();
         });
 
         it("should generate Resource base class", () => {
-            const resource = result.filesGenerated["generated/types/Hl7FhirR4Core/Resource.cs"];
+            const resource = result.filesGenerated.csharp!["generated/types/Hl7FhirR4Core/Resource.cs"];
             expect(resource).toBeDefined();
             expect(resource).toMatchSnapshot();
         });
 
         it("should generate Patient resource", () => {
-            const patient = result.filesGenerated["generated/types/Hl7FhirR4Core/Patient.cs"];
+            const patient = result.filesGenerated.csharp!["generated/types/Hl7FhirR4Core/Patient.cs"];
             expect(patient).toBeDefined();
             expect(patient).toMatchSnapshot();
         });

--- a/test/api/write-generator/multi-package/sql-on-fhir.test.ts
+++ b/test/api/write-generator/multi-package/sql-on-fhir.test.ts
@@ -32,24 +32,26 @@ describe("SQL-on-FHIR", async () => {
         });
 
         it("should generate ViewDefinition type", () => {
-            const viewDef = result.filesGenerated["generated/types/org-sql-on-fhir-ig/ViewDefinition.ts"];
+            const viewDef = result.filesGenerated.typescript!["generated/types/org-sql-on-fhir-ig/ViewDefinition.ts"];
             expect(viewDef).toBeDefined();
             expect(viewDef).toMatchSnapshot();
         });
 
         it("should resolve R5 dependencies (required by SQL-on-FHIR)", () => {
-            const files = Object.keys(result.filesGenerated);
+            const files = Object.keys(result.filesGenerated.typescript!);
             const r5Files = files.filter((f) => f.includes("hl7-fhir-r5-core"));
             expect(r5Files.length).toBe(45);
 
             // Core R5 types should be included
-            expect(result.filesGenerated["generated/types/hl7-fhir-r5-core/Element.ts"]).toBeDefined();
-            expect(result.filesGenerated["generated/types/hl7-fhir-r5-core/DomainResource.ts"]).toBeDefined();
+            expect(result.filesGenerated.typescript!["generated/types/hl7-fhir-r5-core/Element.ts"]).toBeDefined();
+            expect(
+                result.filesGenerated.typescript!["generated/types/hl7-fhir-r5-core/DomainResource.ts"],
+            ).toBeDefined();
         });
 
         it("should generate package index files", () => {
-            expect(result.filesGenerated["generated/types/org-sql-on-fhir-ig/index.ts"]).toBeDefined();
-            expect(result.filesGenerated["generated/types/hl7-fhir-r5-core/index.ts"]).toBeDefined();
+            expect(result.filesGenerated.typescript!["generated/types/org-sql-on-fhir-ig/index.ts"]).toBeDefined();
+            expect(result.filesGenerated.typescript!["generated/types/hl7-fhir-r5-core/index.ts"]).toBeDefined();
         });
     });
 
@@ -65,19 +67,19 @@ describe("SQL-on-FHIR", async () => {
         });
 
         it("should generate ViewDefinition type (promoted logical)", () => {
-            const viewDef = result.filesGenerated["generated/org_sql_on_fhir_ig/view_definition.py"];
+            const viewDef = result.filesGenerated.python!["generated/org_sql_on_fhir_ig/view_definition.py"];
             expect(viewDef).toBeDefined();
             expect(viewDef).toMatchSnapshot();
         });
 
         it("should generate R5 dependency package", () => {
             // Python generator creates R5 base types for dependencies
-            expect(result.filesGenerated["generated/hl7_fhir_r5_core/__init__.py"]).toBeDefined();
-            expect(result.filesGenerated["generated/hl7_fhir_r5_core/domain_resource.py"]).toBeDefined();
+            expect(result.filesGenerated.python!["generated/hl7_fhir_r5_core/__init__.py"]).toBeDefined();
+            expect(result.filesGenerated.python!["generated/hl7_fhir_r5_core/domain_resource.py"]).toBeDefined();
         });
 
         it("should generate domain_resource for R5", () => {
-            const domainResource = result.filesGenerated["generated/hl7_fhir_r5_core/domain_resource.py"];
+            const domainResource = result.filesGenerated.python!["generated/hl7_fhir_r5_core/domain_resource.py"];
             expect(domainResource).toBeDefined();
             expect(domainResource).toMatchSnapshot();
         });
@@ -95,20 +97,20 @@ describe("SQL-on-FHIR", async () => {
         });
 
         it("should generate ViewDefinition type (promoted logical)", () => {
-            const viewDef = result.filesGenerated["generated/types/OrgSqlOnFhirIg/ViewDefinition.cs"];
+            const viewDef = result.filesGenerated.csharp!["generated/types/OrgSqlOnFhirIg/ViewDefinition.cs"];
             expect(viewDef).toBeDefined();
             expect(viewDef).toMatchSnapshot();
         });
 
         it("should generate R5 dependency namespace", () => {
             // C# generator creates R5 types for dependencies
-            const files = Object.keys(result.filesGenerated);
+            const files = Object.keys(result.filesGenerated.csharp!);
             const r5Files = files.filter((f) => f.includes("Hl7FhirR5Core"));
             expect(r5Files.length).toBe(5);
         });
 
         it("should generate DomainResource for R5", () => {
-            const domainResource = result.filesGenerated["generated/types/Hl7FhirR5Core/DomainResource.cs"];
+            const domainResource = result.filesGenerated.csharp!["generated/types/Hl7FhirR5Core/DomainResource.cs"];
             expect(domainResource).toBeDefined();
             expect(domainResource).toMatchSnapshot();
         });

--- a/test/api/write-generator/python.test.ts
+++ b/test/api/write-generator/python.test.ts
@@ -9,31 +9,32 @@ describe("Python Writer Generator", async () => {
         })
         .generate();
     expect(result.success).toBeTrue();
-    expect(Object.keys(result.filesGenerated).length).toEqual(153);
+    const files = result.filesGenerated.python!;
+    expect(Object.keys(files).length).toEqual(153);
     it("generates Patient resource in inMemoryOnly mode with snapshot", async () => {
-        expect(result.filesGenerated["generated/hl7_fhir_r4_core/patient.py"]).toMatchSnapshot();
+        expect(files["generated/hl7_fhir_r4_core/patient.py"]).toMatchSnapshot();
     });
     it("static files", async () => {
-        expect(result.filesGenerated["generated/requirements.txt"]).toMatchSnapshot();
+        expect(files["generated/requirements.txt"]).toMatchSnapshot();
     });
     it("generates Coding with Generic[T] parameter", async () => {
-        const basePy = result.filesGenerated["generated/hl7_fhir_r4_core/base.py"];
+        const basePy = files["generated/hl7_fhir_r4_core/base.py"];
         expect(basePy).toContain("class Coding(Element, Generic[T]):");
         expect(basePy).toContain("code: T | None");
     });
     it("generates CodeableConcept with Generic[T] parameter", async () => {
-        const basePy = result.filesGenerated["generated/hl7_fhir_r4_core/base.py"];
+        const basePy = files["generated/hl7_fhir_r4_core/base.py"];
         expect(basePy).toContain("class CodeableConcept(Element, Generic[T]):");
         expect(basePy).toContain("coding: PyList[Coding[T]] | None");
     });
     it("generates CodeableConcept fields with enum bindings", async () => {
-        const patientPy = result.filesGenerated["generated/hl7_fhir_r4_core/patient.py"];
+        const patientPy = files["generated/hl7_fhir_r4_core/patient.py"];
         expect(patientPy).toContain(
             'marital_status: CodeableConcept[Literal["A", "D", "I", "L", "M", "P", "S", "T", "U", "W", "UNK"] | str] | None',
         );
     });
     it("generates base.py with TypeVar import and declaration", async () => {
-        const basePy = result.filesGenerated["generated/hl7_fhir_r4_core/base.py"];
+        const basePy = files["generated/hl7_fhir_r4_core/base.py"];
         expect(basePy).toContain("from typing import Any, Generic, List as PyList, Literal");
         expect(basePy).toContain("from typing_extensions import TypeVar");
         expect(basePy).toContain("T = TypeVar('T', bound=str, default=str)");

--- a/test/api/write-generator/typescript.test.ts
+++ b/test/api/write-generator/typescript.test.ts
@@ -10,32 +10,33 @@ describe("TypeScript Writer Generator", async () => {
         })
         .generate();
     expect(result.success).toBeTrue();
-    expect(Object.keys(result.filesGenerated).length).toEqual(608);
+    const files = result.filesGenerated.typescript!;
+    expect(Object.keys(files).length).toEqual(608);
     it("generates Patient resource in inMemoryOnly mode with snapshot", async () => {
-        expect(result.filesGenerated["generated/types/hl7-fhir-r4-core/Patient.ts"]).toMatchSnapshot();
+        expect(files["generated/types/hl7-fhir-r4-core/Patient.ts"]).toMatchSnapshot();
     });
     it("generates Coding with generic parameter", async () => {
-        const codingTs = result.filesGenerated["generated/types/hl7-fhir-r4-core/Coding.ts"];
+        const codingTs = files["generated/types/hl7-fhir-r4-core/Coding.ts"];
         expect(codingTs).toContain("export interface Coding<T extends string = string>");
         expect(codingTs).toContain("code?: T");
     });
     it("generates CodeableConcept with generic parameter", async () => {
-        const ccTs = result.filesGenerated["generated/types/hl7-fhir-r4-core/CodeableConcept.ts"];
+        const ccTs = files["generated/types/hl7-fhir-r4-core/CodeableConcept.ts"];
         expect(ccTs).toContain("export interface CodeableConcept<T extends string = string>");
         expect(ccTs).toContain("coding?: Coding<T>[]");
     });
     it("generates BundleEntry with generic type-family parameter", async () => {
-        const bundleTs = result.filesGenerated["generated/types/hl7-fhir-r4-core/Bundle.ts"];
+        const bundleTs = files["generated/types/hl7-fhir-r4-core/Bundle.ts"];
         expect(bundleTs).toContain("export interface BundleEntry<T extends Resource = Resource>");
         expect(bundleTs).toContain("resource?: T");
     });
     it("generates BundleEntryResponse with generic type-family parameter", async () => {
-        const bundleTs = result.filesGenerated["generated/types/hl7-fhir-r4-core/Bundle.ts"];
+        const bundleTs = files["generated/types/hl7-fhir-r4-core/Bundle.ts"];
         expect(bundleTs).toContain("export interface BundleEntryResponse<T extends Resource = Resource>");
         expect(bundleTs).toContain("outcome?: T");
     });
     it("generates DomainResource with generic type-family parameter", async () => {
-        const domainResourceTs = result.filesGenerated["generated/types/hl7-fhir-r4-core/DomainResource.ts"];
+        const domainResourceTs = files["generated/types/hl7-fhir-r4-core/DomainResource.ts"];
         expect(domainResourceTs).toContain("export interface DomainResource<T extends Resource = Resource>");
         expect(domainResourceTs).toContain("contained?: T[]");
     });
@@ -53,13 +54,14 @@ describe("TypeScript CDA with Logical Model Promotion to Resource", async () => 
         })
         .generate();
     expect(result.success).toBeTrue();
+    const files = result.filesGenerated.typescript!;
     it("without resourceType", async () => {
-        expect(result.filesGenerated["generated/types/hl7-cda-uv-core/CV.ts"]).toMatchSnapshot();
-        expect(result.filesGenerated["generated/types/hl7-cda-uv-core/index.ts"]).toMatchSnapshot();
-        expect(result.filesGenerated["generated/types/hl7-cda-uv-core/profiles/index.ts"]).toMatchSnapshot();
+        expect(files["generated/types/hl7-cda-uv-core/CV.ts"]).toMatchSnapshot();
+        expect(files["generated/types/hl7-cda-uv-core/index.ts"]).toMatchSnapshot();
+        expect(files["generated/types/hl7-cda-uv-core/profiles/index.ts"]).toMatchSnapshot();
     });
     it("with resourceType", async () => {
-        expect(result.filesGenerated["generated/types/hl7-cda-uv-core/Material.ts"]).toMatchSnapshot();
+        expect(files["generated/types/hl7-cda-uv-core/Material.ts"]).toMatchSnapshot();
     });
 });
 
@@ -86,16 +88,16 @@ describe("TypeScript R4 Example (with generateProfile)", async () => {
         expect(rewriteWarnings).toMatchSnapshot();
     });
 
+    const files = result.filesGenerated.typescript!;
+
     it("generates bodyweight profile with validate()", () => {
         expect(
-            result.filesGenerated["generated/types/hl7-fhir-r4-core/profiles/Observation_observation_bodyweight.ts"],
+            files["generated/types/hl7-fhir-r4-core/profiles/Observation_observation_bodyweight.ts"],
         ).toMatchSnapshot();
     });
 
     it("generates bp profile with validate()", () => {
-        expect(
-            result.filesGenerated["generated/types/hl7-fhir-r4-core/profiles/Observation_observation_bp.ts"],
-        ).toMatchSnapshot();
+        expect(files["generated/types/hl7-fhir-r4-core/profiles/Observation_observation_bp.ts"]).toMatchSnapshot();
     });
 });
 
@@ -129,31 +131,29 @@ describe("TypeScript US Core Example", async () => {
         expect(result.success).toBeTrue();
     });
 
+    const files = result.filesGenerated.typescript!;
+
     it("generates US Core Patient profile", () => {
-        expect(
-            result.filesGenerated["generated/types/hl7-fhir-us-core/profiles/Patient_USCorePatientProfile.ts"],
-        ).toMatchSnapshot();
+        expect(files["generated/types/hl7-fhir-us-core/profiles/Patient_USCorePatientProfile.ts"]).toMatchSnapshot();
     });
 
     it("generates US Core Blood Pressure profile", () => {
         expect(
-            result.filesGenerated[
-                "generated/types/hl7-fhir-us-core/profiles/Observation_USCoreBloodPressureProfile.ts"
-            ],
+            files["generated/types/hl7-fhir-us-core/profiles/Observation_USCoreBloodPressureProfile.ts"],
         ).toMatchSnapshot();
     });
 
     it("generates US Core Body Weight profile", () => {
         const key = "generated/types/hl7-fhir-us-core/profiles/Observation_USCoreBodyWeightProfile.ts";
-        expect(result.filesGenerated[key]).toMatchSnapshot();
+        expect(files[key]).toMatchSnapshot();
     });
 
     it("generates US Core Race extension profile", () => {
         const key = "generated/types/hl7-fhir-us-core/profiles/Extension_USCoreRaceExtension.ts";
-        expect(result.filesGenerated[key]).toMatchSnapshot();
+        expect(files[key]).toMatchSnapshot();
     });
 
     it("generates US Core profiles index", () => {
-        expect(result.filesGenerated["generated/types/hl7-fhir-us-core/profiles/index.ts"]).toMatchSnapshot();
+        expect(files["generated/types/hl7-fhir-us-core/profiles/index.ts"]).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
## Report structure

- Add `filesByGenerator: Record<string, string[]>` to `GenerationReport`, populated per-generator in `executeGenerators`.
- `prettyReport` renders one section per generator with its own file count and loc total; unattributed files fall into an `other` group.

## New `fileLimit` option

- `prettyReport(report, { fileLimit })` — default `20`.
- When a generator's file list exceeds `fileLimit`, files are aggregated by directory (count + loc per dir) instead of listing every file, keeping the output compact for large generators.

## LOC formatting precision

`formatLoc` no longer collapses everything `>= 1000` to an integer kloc (which was up to ~33% off for small buckets).
- `< 1000` → `N loc`
- `1000–9999` → `N.N kloc` (one decimal)
- `>= 10000` → `N kloc`

## Before / after

Before:
```
Generated files (25 kloc):
  - generated/types/hl7-fhir-r4-core/Patient.ts (125 loc)
  - generated/types/hl7-fhir-r4-core/Observation.ts (340 loc)
  - ... (hundreds of lines)
```

After (small group — listed per file):
```
Generated files (612 files, 25 kloc):
  ir-report (3 files, 480 loc):
    - generated/README.md (120 loc)
    - generated/type-tree.json (260 loc)
    - generated/ir-report.json (100 loc)
  typescript (608 files, 24 kloc):
    - generated/types/hl7-fhir-r4-core/ (600 files, 22 kloc)
    - generated/types/hl7-fhir-r4-core/profiles/ (8 files, 1.5 kloc)
  introspection (1 files, 800 loc):
    - generated/introspection.ndjson (800 loc)
```