### PR TITLE
TS: accept all FHIR literal reference forms in Reference<T>

### DIFF
--- a/examples/typescript-r4/fhir-types/hl7-fhir-r4-core/Reference.ts
+++ b/examples/typescript-r4/fhir-types/hl7-fhir-r4-core/Reference.ts
@@ -13,7 +13,7 @@ export interface Reference<T extends string = string> extends Element {
     display?: string;
     _display?: Element;
     identifier?: Identifier;
-    reference?: `${T}/${string}`;
+    reference?: `${T}/${string}` | `http://${string}` | `https://${string}` | `urn:uuid:${string}` | `urn:oid:${string}` | `#${string}`;
     _reference?: Element;
     type?: string;
     _type?: Element;

--- a/examples/typescript-r4/resource.test.ts
+++ b/examples/typescript-r4/resource.test.ts
@@ -120,3 +120,18 @@ test("Bundle with resources", () => {
     expect(bundle.entry).toHaveLength(2);
     expect(bundle).toMatchSnapshot();
 });
+
+test("Reference accepts all FHIR literal reference forms", () => {
+    // Relative reference — still narrowed to the typed form
+    const relative: Observation["subject"] = { reference: "Patient/123" };
+    // Bundle placeholder — common in transaction bundles
+    const urnUuid: Observation["subject"] = { reference: "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef0123456789" };
+    // OID reference
+    const urnOid: Observation["subject"] = { reference: "urn:oid:2.16.840.1.113883.2.4.6.3" };
+    // Absolute URL
+    const absolute: Observation["subject"] = { reference: "https://example.org/fhir/Patient/123" };
+    // Fragment reference to a contained resource
+    const fragment: Observation["subject"] = { reference: "#contained-1" };
+
+    expect([relative, urnUuid, urnOid, absolute, fragment]).toHaveLength(5);
+});

--- a/examples/typescript-us-core/fhir-types/hl7-fhir-r4-core/Reference.ts
+++ b/examples/typescript-us-core/fhir-types/hl7-fhir-r4-core/Reference.ts
@@ -13,7 +13,7 @@ export interface Reference<T extends string = string> extends Element {
     display?: string;
     _display?: Element;
     identifier?: Identifier;
-    reference?: `${T}/${string}`;
+    reference?: `${T}/${string}` | `http://${string}` | `https://${string}` | `urn:uuid:${string}` | `urn:oid:${string}` | `#${string}`;
     _reference?: Element;
     type?: string;
     _type?: Element;

--- a/src/api/writer-generator/typescript/utils.ts
+++ b/src/api/writer-generator/typescript/utils.ts
@@ -54,7 +54,10 @@ export const tsEnumType = (enumDef: EnumDefinition) => {
 const rewriteFieldTypeDefs: Record<string, Record<string, () => string>> = {
     Coding: { code: () => "T" },
     // biome-ignore lint: that is exactly string what we want
-    Reference: { reference: () => "`${T}/${string}`" },
+    Reference: {
+        reference: () =>
+            "`${T}/${string}` | `http://${string}` | `https://${string}` | `urn:uuid:${string}` | `urn:oid:${string}` | `#${string}`",
+    },
     CodeableConcept: { coding: () => "Coding<T>" },
 };
 

--- a/src/fhir-types/hl7-fhir-r4-core/Reference.ts
+++ b/src/fhir-types/hl7-fhir-r4-core/Reference.ts
@@ -12,6 +12,6 @@ export type { Identifier } from "../hl7-fhir-r4-core/Identifier";
 export interface Reference<T extends string = string> extends Element {
     display?: string;
     identifier?: Identifier;
-    reference?: `${T}/${string}`;
+    reference?: `${T}/${string}` | `http://${string}` | `https://${string}` | `urn:uuid:${string}` | `urn:oid:${string}` | `#${string}`;
     type?: string;
 }


### PR DESCRIPTION
Closes #141.

## Changes

- Widen the generated `Reference<T>.reference` field from `` `${T}/${string}` `` to a union that covers every form allowed by [FHIR references](https://www.hl7.org/fhir/references.html#literal): relative, absolute `http`/`https`, `urn:uuid`, `urn:oid`, and `#fragment`.
- Add a demo in `examples/typescript-r4/resource.test.ts` that assigns each literal form to a typed Reference field, so the widened union is exercised by `tsc`.
- Regenerate `src/fhir-types` and the `typescript-r4` / `typescript-us-core` example fhir-types.

## Before / after

Motivation: `Reference<"Patient">` was rejecting `urn:uuid` placeholders used in transaction Bundles, forcing an inline cast that lies about the string's shape.

Before:
```ts
export interface Reference<T extends string = string> extends Element {
    reference?: `${T}/${string}`;
}

const patientUrn = `urn:uuid:${randomUUID()}`;
const bp = USCoreBloodPressureProfile.create({
    status: "final",
    // ❌ TS2322: Type 'string' is not assignable to type `Patient/${string}`
    subject: { reference: patientUrn },
});
```

After:
```ts
export interface Reference<T extends string = string> extends Element {
    reference?:
        | `${T}/${string}`
        | `http://${string}`
        | `https://${string}`
        | `urn:uuid:${string}`
        | `urn:oid:${string}`
        | `#${string}`;
}

// compiles — no cast required
const bp = USCoreBloodPressureProfile.create({
    status: "final",
    subject: { reference: patientUrn },
});
```