### PR TITLE
Add support for scoped packages

### DIFF
--- a/src/api/writer-generator/typescript/name.ts
+++ b/src/api/writer-generator/typescript/name.ts
@@ -28,7 +28,7 @@ export const tsCamelCase = (name: string): string => {
 };
 
 export const tsPackageDir = (name: string): string => {
-    return kebabCase(name);
+    return kebabCase(name.replace(/[@/]/g, "_"));
 };
 
 export const tsModuleName = (id: TypeIdentifier): string => {


### PR DESCRIPTION
This pull request updates the logic for generating TypeScript package directory names to better handle scoped package names and slashes. The main change replaces all `@` and `/` characters in package names with underscores before converting them to kebab-case, ensuring generated directories are valid and consistent.

* Improved package directory naming:
  * [`src/api/writer-generator/typescript/name.ts`](diffhunk://#diff-0aebb318ca63beb4e23b022e52385889484ed99c369677100d0bcd2d7e6224faL31-R31): Updated `tsPackageDir` to replace all `@` and `/` characters with underscores before applying kebab-case formatting.