### PR TITLE
TypeSchema: better error + skip R5 types in R4-target extensions

### DIFF
--- a/examples/on-the-fly/kbv-r4/generate.ts
+++ b/examples/on-the-fly/kbv-r4/generate.ts
@@ -32,8 +32,9 @@ if (require.main === module) {
         registry: "https://packages.simplifier.net",
         ignorePackageIndex: true,
     })
-        .fromPackage("hl7.fhir.r4.core", "4.0.1")
         .fromPackage("kbv.ita.for", "1.3.1")
+        .fromPackage("de.basisprofil.r4", "1.6.0-ballot2")
+        .fromPackage("kbv.basis", "1.8.0")
         .throwException()
         .typescript({
             withDebugComment: false,

--- a/src/typeschema/core/field-builder.ts
+++ b/src/typeschema/core/field-builder.ts
@@ -15,6 +15,7 @@ import type {
     FieldSlice,
     FieldSlicing,
     Name,
+    PackageMeta,
     RegularField,
     RichFHIRSchema,
     TypeIdentifier,
@@ -24,6 +25,35 @@ import { BINDABLE_TYPES, buildEnum } from "./binding";
 import { mkBindingIdentifier, mkIdentifier } from "./identifier";
 import { mkSliceNameCandidates } from "./name-candidates";
 import { mkNestedIdentifier } from "./nested-types";
+
+const R5_ONLY_TYPES = new Set([
+    "Availability",
+    "CodeableReference",
+    "ExtendedContactDetail",
+    "MonetaryComponent",
+    "RatioRange",
+    "VirtualServiceDetail",
+]);
+
+const dependsOnR4Core = (register: Register, pkg: PackageMeta): boolean => {
+    const pkgIndex = register.resolver[packageMetaToFhir(pkg)];
+    if (!pkgIndex) return false;
+    for (const options of Object.values(pkgIndex.canonicalResolution)) {
+        for (const opt of options) {
+            if (opt.pkg.name === "hl7.fhir.r4.core") return true;
+        }
+    }
+    return false;
+};
+
+const fieldTypeResolutionHint = (register: Register, pkg: PackageMeta, type: string): string => {
+    if (!R5_ONLY_TYPES.has(type)) return "";
+    if (!dependsOnR4Core(register, pkg)) return "";
+    return (
+        `\n  hint:    '${type}' is an R5+ type and is not available when generating against R4.` +
+        `\n           Either skip this canonical via skip-hack.ts, or upgrade the target to R5.`
+    );
+};
 
 function isRequired(register: Register, fhirSchema: RichFHIRSchema, path: string[]): boolean {
     const fieldName = path[path.length - 1];
@@ -283,10 +313,18 @@ export function buildFieldType(
     } else if (element.type) {
         const url = register.ensureSpecializationCanonicalUrl(element.type);
         const fieldFs = register.resolveFs(fhirSchema.package_meta, url);
-        if (!fieldFs)
+        if (!fieldFs) {
+            const pkgId = packageMetaToFhir(fhirSchema.package_meta);
+            const fieldPath = path.join(".");
+            const hint = fieldTypeResolutionHint(register, fhirSchema.package_meta, element.type);
             throw new Error(
-                `Could not resolve field type: <${fhirSchema.url}>.${path.join(".")}: <${element.type}> (pkg: '${packageMetaToFhir(fhirSchema.package_meta)}'))`,
+                `Could not resolve field type:
+  package: ${pkgId}
+  schema:  ${fhirSchema.url}
+  field:   ${fieldPath}
+  type:    ${element.type}${hint}`,
             );
+        }
         return mkIdentifier(fieldFs);
     } else if (element.choices) {
         return undefined;

--- a/src/typeschema/skip-hack.ts
+++ b/src/typeschema/skip-hack.ts
@@ -5,6 +5,8 @@ const availabilityInR4 = "Use Availability which is not provided by FHIR R4.";
 
 export const skipList: Record<string, Record<CanonicalUrl, string>> = {
     "hl7.fhir.uv.extensions.r4": {
+        "http://hl7.org/fhir/StructureDefinition/biologicallyderivedproduct-manipulation": codeableReferenceInR4,
+        "http://hl7.org/fhir/StructureDefinition/biologicallyderivedproduct-processing": codeableReferenceInR4,
         "http://hl7.org/fhir/StructureDefinition/extended-contact-availability": availabilityInR4,
         "http://hl7.org/fhir/StructureDefinition/immunization-procedure": codeableReferenceInR4,
         "http://hl7.org/fhir/StructureDefinition/specimen-additive": codeableReferenceInR4,


### PR DESCRIPTION
## Context

Generating against `kbv.ita.for@1.3.1` together with `de.basisprofil.r4@1.6.0-ballot2` pulls in the transitive dep `hl7.fhir.uv.extensions.r4@5.2.0`. That package ships R4-targeted extensions whose `value[x]` choices are typed as **R5-only** datatypes (`CodeableReference`, `Availability`). On R4 generation those types do not resolve — codegen aborts with an unhelpful single-line error.

## Changes

### `TypeSchema: improve field type resolution error`

Replace the single-line throw in `field-builder.ts` with a structured multi-line message and an R4-context-gated hint.

**Before**

```
Could not resolve field type: <http://hl7.org/fhir/StructureDefinition/biologicallyderivedproduct-manipulation>.valueCodeableReference: <CodeableReference> (pkg: 'hl7.fhir.uv.extensions.r4#5.2.0'))
```

**After**

```
Could not resolve field type:
  package: hl7.fhir.uv.extensions.r4#5.2.0
  schema:  http://hl7.org/fhir/StructureDefinition/biologicallyderivedproduct-manipulation
  field:   valueCodeableReference
  type:    CodeableReference
  hint:    'CodeableReference' is an R5+ type and is not available when generating against R4.
           Either skip this canonical via skip-hack.ts, or upgrade the target to R5.
```

The hint only fires when:
- `element.type` is in `R5_ONLY_TYPES` (`Availability`, `CodeableReference`, `ExtendedContactDetail`, `MonetaryComponent`, `RatioRange`, `VirtualServiceDetail`), AND
- the failing schema's package transitively depends on `hl7.fhir.r4.core` (otherwise the hint would mislead R5 generation).

### `TypeSchema: skip biologicallyderivedproduct R5-typed extensions`

Two more entries in `src/typeschema/skip-hack.ts` for `hl7.fhir.uv.extensions.r4`:
- `biologicallyderivedproduct-manipulation`
- `biologicallyderivedproduct-processing`

Both reference `CodeableReference`. Joins the existing six entries (`extended-contact-availability`, `immunization-procedure`, `specimen-additive`, `workflow-barrier`, `workflow-protectiveFactor`, `workflow-reason`).

### `TypeSchema: extend kbv-r4 example with de.basisprofil + kbv.basis`

Update `examples/on-the-fly/kbv-r4/generate.ts` to pin the cross-package version graph that surfaced the issue:

```diff
-    .fromPackage("hl7.fhir.r4.core", "4.0.1")
     .fromPackage("kbv.ita.for", "1.3.1")
+    .fromPackage("de.basisprofil.r4", "1.6.0-ballot2")
+    .fromPackage("kbv.basis", "1.8.0")
```

`hl7.fhir.r4.core` is now pulled transitively. The example now exercises the R4/R5-extensions interaction so future regressions are caught.

## Notes

- The skip list remains a hardcoded URL allowlist — long-term we want to detect R5-only types automatically. This PR keeps the existing mechanism and only adds the missing entries needed to unblock current users.
- Related discussion: #150, #151.