### PR TITLE
TypeSchema: fix test fixture pollution causing platform-dependent snapshot failures

### DIFF
--- a/test/assets/fhir-schemas/coding.fs.json
+++ b/test/assets/fhir-schemas/coding.fs.json
@@ -1,4 +1,5 @@
 {
+  "package_meta" : { "name" : "realworld.test", "version" : "1.0.0" },
   "description" : "Base StructureDefinition for Coding Type: A reference to a code defined by a terminology system.",
   "derivation" : "specialization",
   "name" : "Coding",

--- a/test/assets/fhir-schemas/string.fs.json
+++ b/test/assets/fhir-schemas/string.fs.json
@@ -1,4 +1,5 @@
 {
+  "package_meta" : { "name" : "realworld.test", "version" : "1.0.0" },
   "description" : "Base StructureDefinition for string Type: A sequence of Unicode characters",
   "derivation" : "specialization",
   "name" : "string",

--- a/test/unit/typeschema/__snapshots__/snapshot.test.ts.snap
+++ b/test/unit/typeschema/__snapshots__/snapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+// Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ValueSet to Type Schema (snapshot) administrative-gender 1`] = `
 "{
@@ -122,6 +122,490 @@ exports[`ValueSet to Type Schema (snapshot) marital-status 1`] = `
     }
   ]
 }"
+`;
+
+exports[`FHIR Schema to Type Schema (snapshot) Real world examples coding primitive type 1`] = `
+"[
+  {
+    "identifier": {
+      "kind": "complex-type",
+      "package": "realworld.test",
+      "version": "1.0.0",
+      "name": "Coding",
+      "url": "http://hl7.org/fhir/StructureDefinition/Coding"
+    },
+    "base": {
+      "kind": "complex-type",
+      "package": "hl7.fhir.r4.core",
+      "version": "4.0.1",
+      "name": "Element",
+      "url": "http://hl7.org/fhir/StructureDefinition/Element"
+    },
+    "fields": {
+      "system": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "uri",
+          "url": "http://hl7.org/fhir/StructureDefinition/uri"
+        },
+        "required": false,
+        "excluded": false,
+        "array": false
+      },
+      "version": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "string",
+          "url": "http://hl7.org/fhir/StructureDefinition/string"
+        },
+        "required": false,
+        "excluded": false,
+        "array": false
+      },
+      "code": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "code",
+          "url": "http://hl7.org/fhir/StructureDefinition/code"
+        },
+        "required": false,
+        "excluded": false,
+        "array": false
+      },
+      "display": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "string",
+          "url": "http://hl7.org/fhir/StructureDefinition/string"
+        },
+        "required": false,
+        "excluded": false,
+        "array": false
+      },
+      "userSelected": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "boolean",
+          "url": "http://hl7.org/fhir/StructureDefinition/boolean"
+        },
+        "required": false,
+        "excluded": false,
+        "array": false
+      }
+    },
+    "description": "Base StructureDefinition for Coding Type: A reference to a code defined by a terminology system.",
+    "dependencies": [
+      {
+        "kind": "primitive-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "boolean",
+        "url": "http://hl7.org/fhir/StructureDefinition/boolean"
+      },
+      {
+        "kind": "primitive-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "code",
+        "url": "http://hl7.org/fhir/StructureDefinition/code"
+      },
+      {
+        "kind": "complex-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "Element",
+        "url": "http://hl7.org/fhir/StructureDefinition/Element"
+      },
+      {
+        "kind": "primitive-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "string",
+        "url": "http://hl7.org/fhir/StructureDefinition/string"
+      },
+      {
+        "kind": "primitive-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "uri",
+        "url": "http://hl7.org/fhir/StructureDefinition/uri"
+      }
+    ]
+  }
+]"
+`;
+
+exports[`FHIR Schema to Type Schema (snapshot) Real world examples string primitive type 1`] = `
+"[
+  {
+    "identifier": {
+      "kind": "primitive-type",
+      "package": "realworld.test",
+      "version": "1.0.0",
+      "name": "string",
+      "url": "http://hl7.org/fhir/StructureDefinition/string"
+    },
+    "description": "Base StructureDefinition for string Type: A sequence of Unicode characters",
+    "base": {
+      "kind": "complex-type",
+      "package": "hl7.fhir.r4.core",
+      "version": "4.0.1",
+      "name": "Element",
+      "url": "http://hl7.org/fhir/StructureDefinition/Element"
+    },
+    "dependencies": [
+      {
+        "kind": "complex-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "Element",
+        "url": "http://hl7.org/fhir/StructureDefinition/Element"
+      }
+    ]
+  }
+]"
+`;
+
+exports[`FHIR Schema to Type Schema (snapshot) Custom resource TutorNotificationTemplate 1`] = `
+"[
+  {
+    "identifier": {
+      "kind": "resource",
+      "package": "mypackage",
+      "version": "0.0.0",
+      "name": "TutorNotificationTemplate",
+      "url": "http://example.com/aidbox-sms-tutor/TutorNotificationTemplate"
+    },
+    "base": {
+      "kind": "resource",
+      "package": "hl7.fhir.r4.core",
+      "version": "4.0.1",
+      "name": "DomainResource",
+      "url": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+    },
+    "fields": {
+      "template": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "string",
+          "url": "http://hl7.org/fhir/StructureDefinition/string"
+        },
+        "required": true,
+        "excluded": false,
+        "array": false
+      }
+    },
+    "dependencies": [
+      {
+        "kind": "resource",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "DomainResource",
+        "url": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+      },
+      {
+        "kind": "primitive-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "string",
+        "url": "http://hl7.org/fhir/StructureDefinition/string"
+      }
+    ]
+  }
+]"
+`;
+
+exports[`FHIR Schema to Type Schema (snapshot) Custom resource TutorNotification 1`] = `
+"[
+  {
+    "identifier": {
+      "kind": "resource",
+      "package": "mypackage",
+      "version": "0.0.0",
+      "name": "TutorNotification",
+      "url": "http://example.com/aidbox-sms-tutor/TutorNotification"
+    },
+    "base": {
+      "kind": "resource",
+      "package": "hl7.fhir.r4.core",
+      "version": "4.0.1",
+      "name": "DomainResource",
+      "url": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+    },
+    "fields": {
+      "type": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "string",
+          "url": "http://hl7.org/fhir/StructureDefinition/string"
+        },
+        "required": true,
+        "excluded": false,
+        "array": false,
+        "binding": {
+          "kind": "binding",
+          "package": "mypackage",
+          "version": "0.0.0",
+          "name": "TutorNotification.type_binding",
+          "url": "http://example.com/aidbox-sms-tutor/TutorNotification#type_binding"
+        },
+        "enum": {
+          "isOpen": false,
+          "values": [
+            "phone",
+            "fax",
+            "email",
+            "pager",
+            "url",
+            "sms",
+            "other"
+          ]
+        }
+      },
+      "status": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "string",
+          "url": "http://hl7.org/fhir/StructureDefinition/string"
+        },
+        "required": true,
+        "excluded": false,
+        "array": false,
+        "binding": {
+          "kind": "binding",
+          "package": "mypackage",
+          "version": "0.0.0",
+          "name": "TutorNotification.status_binding",
+          "url": "http://example.com/aidbox-sms-tutor/TutorNotification#status_binding"
+        },
+        "enum": {
+          "isOpen": false,
+          "values": [
+            "draft",
+            "requested",
+            "received",
+            "accepted",
+            "rejected",
+            "ready",
+            "cancelled",
+            "in-progress",
+            "on-hold",
+            "failed",
+            "completed",
+            "entered-in-error"
+          ]
+        }
+      },
+      "template": {
+        "type": {
+          "kind": "complex-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "Reference",
+          "url": "http://hl7.org/fhir/StructureDefinition/Reference"
+        },
+        "required": true,
+        "excluded": false,
+        "reference": [
+          {
+            "kind": "resource",
+            "package": "mypackage",
+            "version": "0.0.0",
+            "name": "TutorNotificationTemplate",
+            "url": "http://example.com/aidbox-sms-tutor/TutorNotificationTemplate"
+          }
+        ],
+        "array": false
+      },
+      "message": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "string",
+          "url": "http://hl7.org/fhir/StructureDefinition/string"
+        },
+        "required": false,
+        "excluded": false,
+        "array": false
+      },
+      "sendAfter": {
+        "type": {
+          "kind": "primitive-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "dateTime",
+          "url": "http://hl7.org/fhir/StructureDefinition/dateTime"
+        },
+        "required": true,
+        "excluded": false,
+        "array": false
+      },
+      "subject": {
+        "type": {
+          "kind": "complex-type",
+          "package": "hl7.fhir.r4.core",
+          "version": "4.0.1",
+          "name": "Reference",
+          "url": "http://hl7.org/fhir/StructureDefinition/Reference"
+        },
+        "required": true,
+        "excluded": false,
+        "reference": [
+          {
+            "kind": "resource",
+            "package": "hl7.fhir.r4.core",
+            "version": "4.0.1",
+            "name": "Patient",
+            "url": "http://hl7.org/fhir/StructureDefinition/Patient"
+          }
+        ],
+        "array": false
+      }
+    },
+    "dependencies": [
+      {
+        "kind": "binding",
+        "package": "mypackage",
+        "version": "0.0.0",
+        "name": "TutorNotification.status_binding",
+        "url": "http://example.com/aidbox-sms-tutor/TutorNotification#status_binding"
+      },
+      {
+        "kind": "binding",
+        "package": "mypackage",
+        "version": "0.0.0",
+        "name": "TutorNotification.type_binding",
+        "url": "http://example.com/aidbox-sms-tutor/TutorNotification#type_binding"
+      },
+      {
+        "kind": "primitive-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "dateTime",
+        "url": "http://hl7.org/fhir/StructureDefinition/dateTime"
+      },
+      {
+        "kind": "resource",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "DomainResource",
+        "url": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+      },
+      {
+        "kind": "complex-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "Reference",
+        "url": "http://hl7.org/fhir/StructureDefinition/Reference"
+      },
+      {
+        "kind": "primitive-type",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "string",
+        "url": "http://hl7.org/fhir/StructureDefinition/string"
+      }
+    ]
+  },
+  {
+    "identifier": {
+      "kind": "binding",
+      "package": "mypackage",
+      "version": "0.0.0",
+      "name": "TutorNotification.status_binding",
+      "url": "http://example.com/aidbox-sms-tutor/TutorNotification#status_binding"
+    },
+    "valueset": {
+      "kind": "value-set",
+      "package": "hl7.fhir.r4.core",
+      "version": "4.0.1",
+      "name": "TaskStatus",
+      "url": "http://hl7.org/fhir/ValueSet/task-status"
+    },
+    "strength": "required",
+    "enum": {
+      "isOpen": false,
+      "values": [
+        "draft",
+        "requested",
+        "received",
+        "accepted",
+        "rejected",
+        "ready",
+        "cancelled",
+        "in-progress",
+        "on-hold",
+        "failed",
+        "completed",
+        "entered-in-error"
+      ]
+    },
+    "dependencies": [
+      {
+        "kind": "value-set",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "TaskStatus",
+        "url": "http://hl7.org/fhir/ValueSet/task-status"
+      }
+    ]
+  },
+  {
+    "identifier": {
+      "kind": "binding",
+      "package": "mypackage",
+      "version": "0.0.0",
+      "name": "TutorNotification.type_binding",
+      "url": "http://example.com/aidbox-sms-tutor/TutorNotification#type_binding"
+    },
+    "valueset": {
+      "kind": "value-set",
+      "package": "hl7.fhir.r4.core",
+      "version": "4.0.1",
+      "name": "ContactPointSystem",
+      "url": "http://hl7.org/fhir/ValueSet/contact-point-system"
+    },
+    "strength": "required",
+    "enum": {
+      "isOpen": false,
+      "values": [
+        "phone",
+        "fax",
+        "email",
+        "pager",
+        "url",
+        "sms",
+        "other"
+      ]
+    },
+    "dependencies": [
+      {
+        "kind": "value-set",
+        "package": "hl7.fhir.r4.core",
+        "version": "4.0.1",
+        "name": "ContactPointSystem",
+        "url": "http://hl7.org/fhir/ValueSet/contact-point-system"
+      }
+    ]
+  }
+]"
 `;
 
 exports[`FHIR Schema to Type Schema (snapshot) with cardinality 1`] = `
@@ -805,490 +1289,6 @@ exports[`FHIR Schema to Type Schema (snapshot) with resource with nested type 2 
         "version": "4.0.1",
         "name": "string",
         "url": "http://hl7.org/fhir/StructureDefinition/string"
-      }
-    ]
-  }
-]"
-`;
-
-exports[`FHIR Schema to Type Schema (snapshot) Real world examples coding primitive type 1`] = `
-"[
-  {
-    "identifier": {
-      "kind": "complex-type",
-      "package": "mypackage",
-      "version": "0.0.0",
-      "name": "Coding",
-      "url": "http://hl7.org/fhir/StructureDefinition/Coding"
-    },
-    "base": {
-      "kind": "complex-type",
-      "package": "hl7.fhir.r4.core",
-      "version": "4.0.1",
-      "name": "Element",
-      "url": "http://hl7.org/fhir/StructureDefinition/Element"
-    },
-    "fields": {
-      "system": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "hl7.fhir.r4.core",
-          "version": "4.0.1",
-          "name": "uri",
-          "url": "http://hl7.org/fhir/StructureDefinition/uri"
-        },
-        "required": false,
-        "excluded": false,
-        "array": false
-      },
-      "version": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "hl7.fhir.r4.core",
-          "version": "4.0.1",
-          "name": "string",
-          "url": "http://hl7.org/fhir/StructureDefinition/string"
-        },
-        "required": false,
-        "excluded": false,
-        "array": false
-      },
-      "code": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "hl7.fhir.r4.core",
-          "version": "4.0.1",
-          "name": "code",
-          "url": "http://hl7.org/fhir/StructureDefinition/code"
-        },
-        "required": false,
-        "excluded": false,
-        "array": false
-      },
-      "display": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "hl7.fhir.r4.core",
-          "version": "4.0.1",
-          "name": "string",
-          "url": "http://hl7.org/fhir/StructureDefinition/string"
-        },
-        "required": false,
-        "excluded": false,
-        "array": false
-      },
-      "userSelected": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "hl7.fhir.r4.core",
-          "version": "4.0.1",
-          "name": "boolean",
-          "url": "http://hl7.org/fhir/StructureDefinition/boolean"
-        },
-        "required": false,
-        "excluded": false,
-        "array": false
-      }
-    },
-    "description": "Base StructureDefinition for Coding Type: A reference to a code defined by a terminology system.",
-    "dependencies": [
-      {
-        "kind": "primitive-type",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "boolean",
-        "url": "http://hl7.org/fhir/StructureDefinition/boolean"
-      },
-      {
-        "kind": "primitive-type",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "code",
-        "url": "http://hl7.org/fhir/StructureDefinition/code"
-      },
-      {
-        "kind": "complex-type",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "Element",
-        "url": "http://hl7.org/fhir/StructureDefinition/Element"
-      },
-      {
-        "kind": "primitive-type",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "string",
-        "url": "http://hl7.org/fhir/StructureDefinition/string"
-      },
-      {
-        "kind": "primitive-type",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "uri",
-        "url": "http://hl7.org/fhir/StructureDefinition/uri"
-      }
-    ]
-  }
-]"
-`;
-
-exports[`FHIR Schema to Type Schema (snapshot) Real world examples string primitive type 1`] = `
-"[
-  {
-    "identifier": {
-      "kind": "primitive-type",
-      "package": "mypackage",
-      "version": "0.0.0",
-      "name": "string",
-      "url": "http://hl7.org/fhir/StructureDefinition/string"
-    },
-    "description": "Base StructureDefinition for string Type: A sequence of Unicode characters",
-    "base": {
-      "kind": "complex-type",
-      "package": "hl7.fhir.r4.core",
-      "version": "4.0.1",
-      "name": "Element",
-      "url": "http://hl7.org/fhir/StructureDefinition/Element"
-    },
-    "dependencies": [
-      {
-        "kind": "complex-type",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "Element",
-        "url": "http://hl7.org/fhir/StructureDefinition/Element"
-      }
-    ]
-  }
-]"
-`;
-
-exports[`FHIR Schema to Type Schema (snapshot) Custom resource TutorNotificationTemplate 1`] = `
-"[
-  {
-    "identifier": {
-      "kind": "resource",
-      "package": "mypackage",
-      "version": "0.0.0",
-      "name": "TutorNotificationTemplate",
-      "url": "http://example.com/aidbox-sms-tutor/TutorNotificationTemplate"
-    },
-    "base": {
-      "kind": "resource",
-      "package": "hl7.fhir.r4.core",
-      "version": "4.0.1",
-      "name": "DomainResource",
-      "url": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-    },
-    "fields": {
-      "template": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "mypackage",
-          "version": "0.0.0",
-          "name": "string",
-          "url": "http://hl7.org/fhir/StructureDefinition/string"
-        },
-        "required": true,
-        "excluded": false,
-        "array": false
-      }
-    },
-    "dependencies": [
-      {
-        "kind": "resource",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "DomainResource",
-        "url": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-      },
-      {
-        "kind": "primitive-type",
-        "package": "mypackage",
-        "version": "0.0.0",
-        "name": "string",
-        "url": "http://hl7.org/fhir/StructureDefinition/string"
-      }
-    ]
-  }
-]"
-`;
-
-exports[`FHIR Schema to Type Schema (snapshot) Custom resource TutorNotification 1`] = `
-"[
-  {
-    "identifier": {
-      "kind": "resource",
-      "package": "mypackage",
-      "version": "0.0.0",
-      "name": "TutorNotification",
-      "url": "http://example.com/aidbox-sms-tutor/TutorNotification"
-    },
-    "base": {
-      "kind": "resource",
-      "package": "hl7.fhir.r4.core",
-      "version": "4.0.1",
-      "name": "DomainResource",
-      "url": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-    },
-    "fields": {
-      "type": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "mypackage",
-          "version": "0.0.0",
-          "name": "string",
-          "url": "http://hl7.org/fhir/StructureDefinition/string"
-        },
-        "required": true,
-        "excluded": false,
-        "array": false,
-        "binding": {
-          "kind": "binding",
-          "package": "mypackage",
-          "version": "0.0.0",
-          "name": "TutorNotification.type_binding",
-          "url": "http://example.com/aidbox-sms-tutor/TutorNotification#type_binding"
-        },
-        "enum": {
-          "isOpen": false,
-          "values": [
-            "phone",
-            "fax",
-            "email",
-            "pager",
-            "url",
-            "sms",
-            "other"
-          ]
-        }
-      },
-      "status": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "mypackage",
-          "version": "0.0.0",
-          "name": "string",
-          "url": "http://hl7.org/fhir/StructureDefinition/string"
-        },
-        "required": true,
-        "excluded": false,
-        "array": false,
-        "binding": {
-          "kind": "binding",
-          "package": "mypackage",
-          "version": "0.0.0",
-          "name": "TutorNotification.status_binding",
-          "url": "http://example.com/aidbox-sms-tutor/TutorNotification#status_binding"
-        },
-        "enum": {
-          "isOpen": false,
-          "values": [
-            "draft",
-            "requested",
-            "received",
-            "accepted",
-            "rejected",
-            "ready",
-            "cancelled",
-            "in-progress",
-            "on-hold",
-            "failed",
-            "completed",
-            "entered-in-error"
-          ]
-        }
-      },
-      "template": {
-        "type": {
-          "kind": "complex-type",
-          "package": "hl7.fhir.r4.core",
-          "version": "4.0.1",
-          "name": "Reference",
-          "url": "http://hl7.org/fhir/StructureDefinition/Reference"
-        },
-        "required": true,
-        "excluded": false,
-        "reference": [
-          {
-            "kind": "resource",
-            "package": "mypackage",
-            "version": "0.0.0",
-            "name": "TutorNotificationTemplate",
-            "url": "http://example.com/aidbox-sms-tutor/TutorNotificationTemplate"
-          }
-        ],
-        "array": false
-      },
-      "message": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "mypackage",
-          "version": "0.0.0",
-          "name": "string",
-          "url": "http://hl7.org/fhir/StructureDefinition/string"
-        },
-        "required": false,
-        "excluded": false,
-        "array": false
-      },
-      "sendAfter": {
-        "type": {
-          "kind": "primitive-type",
-          "package": "hl7.fhir.r4.core",
-          "version": "4.0.1",
-          "name": "dateTime",
-          "url": "http://hl7.org/fhir/StructureDefinition/dateTime"
-        },
-        "required": true,
-        "excluded": false,
-        "array": false
-      },
-      "subject": {
-        "type": {
-          "kind": "complex-type",
-          "package": "hl7.fhir.r4.core",
-          "version": "4.0.1",
-          "name": "Reference",
-          "url": "http://hl7.org/fhir/StructureDefinition/Reference"
-        },
-        "required": true,
-        "excluded": false,
-        "reference": [
-          {
-            "kind": "resource",
-            "package": "hl7.fhir.r4.core",
-            "version": "4.0.1",
-            "name": "Patient",
-            "url": "http://hl7.org/fhir/StructureDefinition/Patient"
-          }
-        ],
-        "array": false
-      }
-    },
-    "dependencies": [
-      {
-        "kind": "binding",
-        "package": "mypackage",
-        "version": "0.0.0",
-        "name": "TutorNotification.status_binding",
-        "url": "http://example.com/aidbox-sms-tutor/TutorNotification#status_binding"
-      },
-      {
-        "kind": "binding",
-        "package": "mypackage",
-        "version": "0.0.0",
-        "name": "TutorNotification.type_binding",
-        "url": "http://example.com/aidbox-sms-tutor/TutorNotification#type_binding"
-      },
-      {
-        "kind": "primitive-type",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "dateTime",
-        "url": "http://hl7.org/fhir/StructureDefinition/dateTime"
-      },
-      {
-        "kind": "resource",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "DomainResource",
-        "url": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-      },
-      {
-        "kind": "complex-type",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "Reference",
-        "url": "http://hl7.org/fhir/StructureDefinition/Reference"
-      },
-      {
-        "kind": "primitive-type",
-        "package": "mypackage",
-        "version": "0.0.0",
-        "name": "string",
-        "url": "http://hl7.org/fhir/StructureDefinition/string"
-      }
-    ]
-  },
-  {
-    "identifier": {
-      "kind": "binding",
-      "package": "mypackage",
-      "version": "0.0.0",
-      "name": "TutorNotification.status_binding",
-      "url": "http://example.com/aidbox-sms-tutor/TutorNotification#status_binding"
-    },
-    "valueset": {
-      "kind": "value-set",
-      "package": "hl7.fhir.r4.core",
-      "version": "4.0.1",
-      "name": "TaskStatus",
-      "url": "http://hl7.org/fhir/ValueSet/task-status"
-    },
-    "strength": "required",
-    "enum": {
-      "isOpen": false,
-      "values": [
-        "draft",
-        "requested",
-        "received",
-        "accepted",
-        "rejected",
-        "ready",
-        "cancelled",
-        "in-progress",
-        "on-hold",
-        "failed",
-        "completed",
-        "entered-in-error"
-      ]
-    },
-    "dependencies": [
-      {
-        "kind": "value-set",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "TaskStatus",
-        "url": "http://hl7.org/fhir/ValueSet/task-status"
-      }
-    ]
-  },
-  {
-    "identifier": {
-      "kind": "binding",
-      "package": "mypackage",
-      "version": "0.0.0",
-      "name": "TutorNotification.type_binding",
-      "url": "http://example.com/aidbox-sms-tutor/TutorNotification#type_binding"
-    },
-    "valueset": {
-      "kind": "value-set",
-      "package": "hl7.fhir.r4.core",
-      "version": "4.0.1",
-      "name": "ContactPointSystem",
-      "url": "http://hl7.org/fhir/ValueSet/contact-point-system"
-    },
-    "strength": "required",
-    "enum": {
-      "isOpen": false,
-      "values": [
-        "phone",
-        "fax",
-        "email",
-        "pager",
-        "url",
-        "sms",
-        "other"
-      ]
-    },
-    "dependencies": [
-      {
-        "kind": "value-set",
-        "package": "hl7.fhir.r4.core",
-        "version": "4.0.1",
-        "name": "ContactPointSystem",
-        "url": "http://hl7.org/fhir/ValueSet/contact-point-system"
       }
     ]
   }


### PR DESCRIPTION
## Problem

- `test/assets/fhir-schemas/string.fs.json` and `coding.fs.json` use canonical FHIR URLs (`http://hl7.org/fhir/StructureDefinition/string`, `…/Coding`) but ship without a `package_meta` field, so the `registerFs` test helper defaults them to `mypackage@0.0.0`.
- `testAppendFs` inserts them into the shared `r4` register under that fake package id, colliding with the pre-loaded `hl7.fhir.r4.core@4.0.1` entries at the same URLs.
- Later tests resolving primitive type references from a `mypackage` context hit the `resolveFs` fallback at `src/typeschema/register.ts:190-193`, which returns any `fhirSchemas` entry whose `package_meta.name` matches the caller — silently returning the polluted entry.
- Whether the bug becomes visible depends on `Object.values()` iteration order across runtimes — `bun test` is green on Linux x64 (CI), red on macOS arm64 (4 snapshot failures).

## Fix

- Add an explicit `"package_meta": { "name": "realworld.test", "version": "1.0.0" }` to the two shared-URL fixtures.
- Regenerate `test/unit/typeschema/__snapshots__/snapshot.test.ts.snap`.

## Snapshot diff — 8 semantic changes total

Verified by counting `"package": "mypackage"` occurrences: 30 → 22.

- **2 expected flips**: identifier `package` in `Real world examples > coding|string primitive type` snapshots → `realworld.test@1.0.0` (matches the new `package_meta`).
- **6 silent corrections**: primitive `string` references in `Custom resource > TutorNotification(Template)` snapshots and in the previously-failing `with cardinality | with resource with string | with resource with nested type | with resource with nested type 2` snapshots now correctly attribute to `hl7.fhir.r4.core@4.0.1`. The `TutorNotification*` snapshots had the wrong attribution baked in before this fix and were passing silently with incorrect data.

The remaining 22 `mypackage` occurrences are legitimate (test resource identifiers, bindings, reference targets).

## Verification

- `bun test test/unit/typeschema/snapshot.test.ts` on macOS arm64: 10/14 → 14/14
- Full suite (`bun test`): 257/257 (formerly 253/257 on macOS arm64; unchanged on Linux x64)
- `bun run typecheck` and `bun run lint`: green

## Before / after — primitive type attribution in `Custom resource > TutorNotification`

Before this fix, the `template.message.type` field for a `mypackage`-defined resource referencing the primitive `string` resolved as:

```json
"type": {
  "kind": "primitive-type",
  "package": "mypackage",
  "version": "0.0.0",
  "name": "string",
  "url": "http://hl7.org/fhir/StructureDefinition/string"
}
```

After:

```json
"type": {
  "kind": "primitive-type",
  "package": "hl7.fhir.r4.core",
  "version": "4.0.1",
  "name": "string",
  "url": "http://hl7.org/fhir/StructureDefinition/string"
}
```