### PR TITLE
CI: bump Node to 22 for package-managers job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         if: matrix.package-manager != 'bun'
         uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Setup pnpm
         if: matrix.package-manager == 'pnpm'


### PR DESCRIPTION
- Bump Node from 20 to 22 in the `package-managers` matrix job in `.github/workflows/ci.yml`.
- The job pulls `pnpm@latest` via `pnpm/action-setup@v5`, which now resolves to pnpm 11. pnpm 11 requires Node >= 22.13 because it imports `node:sqlite`, a builtin that does not exist in Node 20.
- Symptom on `main` and on PR #155: `package-managers (pnpm)` fails before installing the tarball with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`. The `npm` and `bun` variants of the same matrix pass.
- Scope intentionally minimal: `release.yml` and the rest of the Node-20 references are unchanged.