### PR TITLE
TypeSchema/TS: drop isWithMetaField; inline isResourceIdentifier(base)

### DIFF
--- a/docs/guides/typeschema-index.md
+++ b/docs/guides/typeschema-index.md
@@ -115,9 +115,6 @@ Work with FHIR profiles and their constraints:
 ```typescript
 flatProfile(schema: ProfileTypeSchema): ProfileTypeSchema
   Flattens a profile by resolving all differential constraints into a complete snapshot
-
-isWithMetaField(profile: ProfileTypeSchema): boolean
-  Checks if a profile includes the meta field
 ```
 
 ---
@@ -172,7 +169,6 @@ const specializedId = tsIndex.findLastSpecializationByIdentifier(patientIdentifi
 
 ```typescript
 const flatProfile = tsIndex.flatProfile(useCorePatientProfile);
-const hasMeta = tsIndex.isWithMetaField(profile);
 ```
 
 ### Debug Utilities

--- a/src/api/writer-generator/typescript/profile.ts
+++ b/src/api/writer-generator/typescript/profile.ts
@@ -226,13 +226,12 @@ export const generateProfileIndexFile = (
 
 const generateProfileHelpersImport = (
     w: TypeScript,
-    tsIndex: TypeSchemaIndex,
     flatProfile: ProfileTypeSchema,
     sliceDefs: SliceDef[],
     factoryInfo: ProfileFactoryInfo,
 ) => {
     const extensions = flatProfile.extensions ?? [];
-    const hasMeta = tsIndex.isWithMetaField(flatProfile);
+    const hasMeta = isResourceIdentifier(flatProfile.base);
     const canonicalUrl = flatProfile.identifier.url;
 
     const imports: string[] = [];
@@ -356,15 +355,10 @@ const generateStaticSliceFields = (w: TypeScript, sliceDefs: SliceDef[]) => {
     if (sliceDefs.length > 0) w.line();
 };
 
-const generateFactoryMethods = (
-    w: TypeScript,
-    tsIndex: TypeSchemaIndex,
-    flatProfile: ProfileTypeSchema,
-    factoryInfo: ProfileFactoryInfo,
-) => {
+const generateFactoryMethods = (w: TypeScript, flatProfile: ProfileTypeSchema, factoryInfo: ProfileFactoryInfo) => {
     const profileClassName = tsProfileClassName(flatProfile);
     const tsBaseResourceName = tsTypeFromIdentifier(flatProfile.base);
-    const hasMeta = tsIndex.isWithMetaField(flatProfile);
+    const hasMeta = isResourceIdentifier(flatProfile.base);
     const hasParams = factoryInfo.params.length > 0 || factoryInfo.sliceAutoFields.length > 0;
     const createArgsTypeName = `${profileClassName}Raw`;
     const paramSignature = hasParams ? `args: ${createArgsTypeName}` : "";
@@ -391,11 +385,11 @@ const generateFactoryMethods = (
         w.lineSM("return profile");
     });
     w.line();
-    const canEmitIs = (hasMeta && isResourceIdentifier(flatProfile.base)) || flatProfile.base.name === "Extension";
+    const canEmitIs = hasMeta || flatProfile.base.name === "Extension";
     if (canEmitIs) {
         w.curlyBlock(["static", "is", "(resource: unknown)", `: resource is ${tsBaseResourceName}`], () => {
             w.line(`if (typeof resource !== "object" || resource === null) return false;`);
-            if (hasMeta && isResourceIdentifier(flatProfile.base)) {
+            if (hasMeta) {
                 w.line(`const r = resource as { resourceType?: string; meta?: { profile?: string[] } };`);
                 w.line(`if (r.resourceType !== ${JSON.stringify(flatProfile.base.name)}) return false;`);
                 w.lineSM(`return (r.meta?.profile ?? []).includes(${profileClassName}.canonicalUrl)`);
@@ -754,7 +748,7 @@ export const generateProfileClass = (w: TypeScript, tsIndex: TypeSchemaIndex, fl
     generateInlineExtensionInputTypes(w, tsIndex, flatProfile);
     generateSliceInputTypes(w, flatProfile, sliceDefs);
 
-    generateProfileHelpersImport(w, tsIndex, flatProfile, sliceDefs, factoryInfo);
+    generateProfileHelpersImport(w, flatProfile, sliceDefs, factoryInfo);
 
     generateRawType(w, flatProfile, factoryInfo);
     generateFlatInputType(w, flatProfile);
@@ -768,7 +762,7 @@ export const generateProfileClass = (w: TypeScript, tsIndex: TypeSchemaIndex, fl
         generateStaticSliceFields(w, sliceDefs);
         w.lineSM(`private resource: ${tsBaseResourceName}`);
         w.line();
-        generateFactoryMethods(w, tsIndex, flatProfile, factoryInfo);
+        generateFactoryMethods(w, flatProfile, factoryInfo);
         generateFieldAccessors(w, factoryInfo);
 
         w.line("// Extensions");

--- a/src/typeschema/utils.ts
+++ b/src/typeschema/utils.ts
@@ -314,7 +314,6 @@ export type TypeSchemaIndex = {
         baseTypeId: TypeIdentifier,
         sliceElements: string[],
     ) => ConstrainedChoiceInfo | undefined;
-    isWithMetaField: (profile: ProfileTypeSchema) => boolean;
     entityTree: () => EntityTree;
     exportTree: (filename: string) => Promise<void>;
     irReport: () => IrReport;
@@ -573,14 +572,6 @@ export const mkTypeSchemaIndex = (
         return undefined;
     };
 
-    const isWithMetaField = (profile: ProfileTypeSchema): boolean => {
-        const genealogy = tryHierarchy(profile);
-        if (!genealogy) return false;
-        return genealogy.filter(isSpecializationTypeSchema).some((schema) => {
-            return schema.fields?.meta !== undefined;
-        });
-    };
-
     const entityTree = () => {
         const tree: EntityTree = {};
         for (const [pkgId, shemas] of Object.entries(groupByPackages(schemas))) {
@@ -626,7 +617,6 @@ export const mkTypeSchemaIndex = (
         findLastSpecializationByIdentifier,
         flatProfile,
         constrainedChoice,
-        isWithMetaField,
         entityTree,
         exportTree,
         irReport: () => irReport,


### PR DESCRIPTION
In FHIR only resources carry `meta`, so the hierarchy walk in `isWithMetaField` is equivalent to `isResourceIdentifier(flatProfile.base)`. Inlining the check removes a redundant index helper and simplifies a couple of writer conditions.

## Changes

- Remove `isWithMetaField` from `TypeSchemaIndex` (interface, implementation, return-object key).
- Inline `isResourceIdentifier(flatProfile.base)` at both call sites in `src/api/writer-generator/typescript/profile.ts`.
- Simplify `canEmitIs` from `(hasMeta && isResourceIdentifier(base)) || base.name === "Extension"` to `hasMeta || base.name === "Extension"`, and the nested branch from `hasMeta && isResourceIdentifier(base)` to just `hasMeta`.
- Drop now-unused `tsIndex` params from `generateProfileHelpersImport` and `generateFactoryMethods`.
- Remove the stale entry from `docs/guides/typeschema-index.md`.

## Verification

- `bun run typecheck` clean
- `bunx biome check` clean (only pre-existing warnings)
- `bun test` 257/257 pass
- R4 and US Core examples regenerate byte-identical