### PR TITLE
TS: demonstrate fixed[x] merge corner case (WIP)

### DIFF
--- a/examples/local-package-folder/__snapshots__/profile-fixed-marital-status.test.ts.snap
+++ b/examples/local-package-folder/__snapshots__/profile-fixed-marital-status.test.ts.snap
@@ -1,0 +1,44 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`demo: create() materializes the fixed maritalStatus create() produces exactly the fixed CodeableConcept 1`] = `
+{
+  "maritalStatus": {
+    "coding": [
+      {
+        "code": "M",
+        "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+      },
+    ],
+  },
+  "meta": {
+    "profile": [
+      "http://example.org/fhir/StructureDefinition/PatientFixedMaritalStatus",
+    ],
+  },
+  "resourceType": "Patient",
+}
+`;
+
+exports[`corner case: apply() merges a true fixed[x] instead of replacing it conflicting caller coding and text survive the fixed-value apply() 1`] = `
+{
+  "maritalStatus": {
+    "coding": [
+      {
+        "code": "S",
+        "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+      },
+      {
+        "code": "M",
+        "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+      },
+    ],
+    "text": "Never married (caller-provided)",
+  },
+  "meta": {
+    "profile": [
+      "http://example.org/fhir/StructureDefinition/PatientFixedMaritalStatus",
+    ],
+  },
+  "resourceType": "Patient",
+}
+`;

--- a/examples/local-package-folder/generate.ts
+++ b/examples/local-package-folder/generate.ts
@@ -23,6 +23,7 @@ async function generateFromLocalPackageFolder() {
                     "http://example.org/fhir/StructureDefinition/ExampleNotebook": {},
                     "http://example.org/fhir/StructureDefinition/ExampleTypedBundle": {},
                     "http://example.org/fhir/StructureDefinition/PatientMetaRequired": {},
+                    "http://example.org/fhir/StructureDefinition/PatientFixedMaritalStatus": {},
                 },
                 "hl7.fhir.r4.core": {
                     "http://hl7.org/fhir/StructureDefinition/Patient": {},

--- a/examples/local-package-folder/profile-fixed-marital-status.test.ts
+++ b/examples/local-package-folder/profile-fixed-marital-status.test.ts
@@ -1,0 +1,65 @@
+/**
+ * PatientFixedMaritalStatus profile — demonstrates the corner case for a *true*
+ * fixedCodeableConcept (FHIR `fixed[x]`, which has exact-equality semantics).
+ *
+ * The generator emits the same merging `applyFixedValue(...)` for `fixed[x]` as it does
+ * for `pattern[x]` / slice discriminators. For a genuine `fixed[x]`, FHIR requires the
+ * element to be *exactly equal* to the fixed value, so any conflicting or extra caller
+ * data must be dropped. The generated code instead merges and keeps it — and `validate()`
+ * accepts the result because `validateFixedValue` checks containment, not equality.
+ *
+ * These tests pin down that current behavior on real generated code, so a future fix that
+ * branches on `valueConstraint.kind` ("fixed" -> replace, "pattern" -> merge) has a clear
+ * failing anchor to update.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { PatientFixedMaritalStatusProfile } from "./fhir-types/example-folder-structures/profiles/Patient_PatientFixedMaritalStatus";
+import type { Patient } from "./fhir-types/hl7-fhir-r4-core/Patient";
+
+const maritalSystem = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus";
+
+describe("demo: create() materializes the fixed maritalStatus", () => {
+    test("create() produces exactly the fixed CodeableConcept", () => {
+        const profile = PatientFixedMaritalStatusProfile.create();
+        const resource = profile.toResource();
+
+        // Built from scratch, so the element equals exactly the fixed value.
+        expect(resource.maritalStatus).toEqual({ coding: [{ system: maritalSystem, code: "M" }] });
+        expect(profile.validate().errors).toEqual([]);
+        expect(resource).toMatchSnapshot();
+    });
+});
+
+describe("corner case: apply() merges a true fixed[x] instead of replacing it", () => {
+    test("conflicting caller coding and text survive the fixed-value apply()", () => {
+        // Caller already set maritalStatus to a *different* code in the same system, plus free text.
+        const patient: Patient = {
+            resourceType: "Patient",
+            maritalStatus: {
+                text: "Never married (caller-provided)",
+                coding: [{ system: maritalSystem, code: "S" }],
+            },
+        };
+
+        const profile = PatientFixedMaritalStatusProfile.apply(patient);
+        const resource = profile.toResource();
+
+        // FHIR `fixed[x]` would require: maritalStatus === { coding: [{ system, code: "M" }] }
+        // i.e. the caller's text and the conflicting "S" coding dropped. Instead the merge keeps
+        // the caller text and *appends* the fixed "M" coding next to the conflicting "S" one.
+        expect(resource.maritalStatus).toEqual({
+            text: "Never married (caller-provided)",
+            coding: [
+                { system: maritalSystem, code: "S" },
+                { system: maritalSystem, code: "M" },
+            ],
+        });
+
+        // ...and validate() passes anyway: validateFixedValue uses containment (matchesValue), so
+        // the mere presence of the fixed coding satisfies it even though the resource is not
+        // exactly equal to the fixed value a strict `fixed[x]` would mandate.
+        expect(profile.validate().errors).toEqual([]);
+        expect(resource).toMatchSnapshot();
+    });
+});

--- a/examples/local-package-folder/structure-definitions/patient-fixed-marital-status.structuredefinition.json
+++ b/examples/local-package-folder/structure-definitions/patient-fixed-marital-status.structuredefinition.json
@@ -1,0 +1,32 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "patient-fixed-marital-status",
+  "url": "http://example.org/fhir/StructureDefinition/PatientFixedMaritalStatus",
+  "version": "0.0.1",
+  "name": "PatientFixedMaritalStatus",
+  "title": "Patient Profile with a fixed maritalStatus CodeableConcept",
+  "status": "draft",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.maritalStatus",
+        "path": "Patient.maritalStatus",
+        "min": 1,
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              "code": "M"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Draft — adds a failing-by-design demonstration of the `fixed[x]` vs `pattern[x]` issue from #165. **Test only; the codegen fix is not included yet.**

## Context

#165 made generated profile `apply()` merge fixed values (`applyFixedValue`) instead of overwriting them. That is correct for `pattern[x]` and slice discriminators, but a true FHIR `fixed[x]` requires the element to be **exactly equal** to the fixed value. The generator does not branch on `valueConstraint.kind`, so `fixed[x]` is merged too — and `validateFixedValue` uses containment (`matchesValue`), so it accepts the merged result.

## What this PR adds

- New `PatientFixedMaritalStatus` StructureDefinition — a true `fixedCodeableConcept` on `Patient.maritalStatus` (not a coding slice), registered in the example tree-shake config.
- `examples/local-package-folder/profile-fixed-marital-status.test.ts` — runtime tests against the generated profile class:
  - `create()` materializes exactly the fixed CodeableConcept.
  - `apply()` on a resource that already carries a conflicting coding (same system, different code) + free `text` **merges** rather than replacing — caller data survives and the fixed coding is appended — yet `validate().errors` is empty.

The generated `apply()` confirms a real `fixed[x]` reaches the merge path:

```ts
applyFixedValue(resource, "maritalStatus", {"coding":[{"system":".../v3-MaritalStatus","code":"M"}]});
```

## TODO before un-drafting

- Decide and implement the fix: branch generation on `valueConstraint.kind` (`"fixed"` → exact replace, `"pattern"` → merge), and relabel the synthesized fixed-coding-slice constraint (`field-builder.ts`) as `pattern`.
- Update these assertions to the corrected (exact-replace) behavior once the fix lands.