### PR TITLE
TypeSchema: skip base choice declarations in inheritedRequiredFields

### DIFF
--- a/src/typeschema/utils.ts
+++ b/src/typeschema/utils.ts
@@ -619,6 +619,13 @@ export const mkTypeSchemaIndex = (
         if (nonConstraintSchema?.fields) {
             for (const [name, baseField] of Object.entries(nonConstraintSchema.fields)) {
                 if (!baseField.required) continue;
+                // Choice declarations (e.g. `value[x]`) are required via the
+                // declaration, not a real property — validateRequired() would
+                // check a key that never exists in FHIR JSON. The correct
+                // validateChoiceRequired() handling is deferred to the per-type
+                // validator redesign (#169); until then, skip rather than emit
+                // a check that can only misfire.
+                if (isChoiceDeclarationField(baseField)) continue;
                 const flat = flatFields[name] as { required?: boolean; min?: number } | undefined;
                 // Profile explicitly relaxed the field via differential min:0 →
                 // skip (regular validate emission also skips it because flatField

--- a/test/unit/typeschema/utils.test.ts
+++ b/test/unit/typeschema/utils.test.ts
@@ -740,5 +740,45 @@ describe("TypeSchema Index", () => {
 
             expect(snap.inheritedRequiredFields).toEqual(["target", "recorded", "agent"]);
         });
+
+        it("skips a base-required choice declaration the profile does not re-state", () => {
+            // A required choice (`value[x]`, 1..1) is satisfied via one of its
+            // variants, not a property literally named "value[x]". Listing it in
+            // inheritedRequiredFields would emit validateRequired("value[x]") —
+            // a check against a key that never exists in FHIR JSON. It must be
+            // skipped (proper validateChoiceRequired handling is tracked in #169).
+            const base: SpecializationTypeSchema = {
+                identifier: {
+                    name: "Observationish" as Name,
+                    package: "test",
+                    kind: "resource",
+                    version: "1.0.0",
+                    url: "http://example.org/StructureDefinition/Observationish" as CanonicalUrl,
+                },
+                fields: {
+                    recorded: { type: stringType, required: true, array: false },
+                    "value[x]": { choices: ["valueString", "valueQuantity"], required: true },
+                },
+            };
+            const profile: ProfileTypeSchema = {
+                identifier: {
+                    name: "ObservationishProfile" as Name,
+                    package: "test",
+                    kind: "profile",
+                    version: "1.0.0",
+                    url: "http://example.org/StructureDefinition/ObservationishProfile" as CanonicalUrl,
+                },
+                base: base.identifier,
+                fields: {},
+            };
+
+            const index = mkTypeSchemaIndex([base, profile], {});
+            const snap = index.collectSnapshotProfiles().find((s) => s.identifier.name === "ObservationishProfile");
+            if (!snap) throw new Error("snapshot not built");
+
+            // recorded is inherited; value[x] is a choice declaration → skipped.
+            expect(snap.inheritedRequiredFields).toEqual(["recorded"]);
+            expect(snap.inheritedRequiredFields).not.toContain("value[x]");
+        });
     });
 });


### PR DESCRIPTION
Follow-up to #166. The `inheritedRequiredFields` collection pushed any base-required field by name, including **choice declarations**.

A required base choice (e.g. `value[x]`, `1..1`) is satisfied via one of its variants — there is no property literally named `value[x]` in FHIR JSON. Emitting `validateRequired(res, profileName, "value[x]")` for it produces a check that can only misfire. This skips choice-declaration base fields in the collection loop.

Proper `validateChoiceRequired()` handling for inherited required choices is deferred to the per-type validator redesign in #169, which replaces this collection path entirely.

Generated code — a profile inheriting a base-required `value[x]` it does not re-state:

Before:
```typescript
...validateRequired(res, profileName, "value[x]"),   // checks a key that never exists
```

After:
```typescript
// (no call emitted; tracked for validateChoiceRequired in #169)
```

- `src/typeschema/utils.ts`: skip `isChoiceDeclarationField` base fields in `buildProfileSnapshot`'s inherited-required collection.
- `test/unit/typeschema/utils.test.ts`: regression covering a base-required `value[x]` left un-restated by the profile.
