### PR TITLE
TypeSchema: terminate package dependency walk on cyclic deps

### DIFF
--- a/src/typeschema/register.ts
+++ b/src/typeschema/register.ts
@@ -93,6 +93,9 @@ const mkPackageAwareResolver = async (
     if (acc[pkgId]) return acc[pkgId];
 
     const index = mkEmptyPkgIndex(pkg);
+    // Memoize before recursing into dependencies so cyclic deps (e.g. hl7.terminology.r5 ↔
+    // hl7.fhir.uv.extensions.r5) terminate at the guard above instead of recursing forever.
+    acc[pkgId] = index;
     for (const resource of await manager.search({ package: pkg })) {
         const rawUrl = resource.url;
         if (!rawUrl) continue;
@@ -115,7 +118,6 @@ const mkPackageAwareResolver = async (
         resolutionOptions.sort((a, b) => a.deep - b.deep);
     }
 
-    acc[pkgId] = index;
     return index;
 };
 

--- a/src/typeschema/register.ts
+++ b/src/typeschema/register.ts
@@ -93,8 +93,6 @@ const mkPackageAwareResolver = async (
     if (acc[pkgId]) return acc[pkgId];
 
     const index = mkEmptyPkgIndex(pkg);
-    // Memoize before recursing into dependencies so cyclic deps (e.g. hl7.terminology.r5 ↔
-    // hl7.fhir.uv.extensions.r5) terminate at the guard above instead of recursing forever.
     acc[pkgId] = index;
     for (const resource of await manager.search({ package: pkg })) {
         const rawUrl = resource.url;

--- a/test/unit/typeschema/register.test.ts
+++ b/test/unit/typeschema/register.test.ts
@@ -159,8 +159,11 @@ describe("Register tests", async () => {
 describe("cyclic package dependencies", () => {
     it("registerFromManager terminates on a dependency cycle", async () => {
         // a ↔ b mutually depend (like hl7.terminology.r5 ↔ hl7.fhir.uv.extensions.r5).
-        // Without guarding the dependency walk this recurses until stack overflow / OOM.
+        // Without memoizing each package before recursing into its deps, the walk recurses
+        // forever; each unique package should be visited exactly once. The search-call cap
+        // makes a regression fail fast (red) instead of slowly exhausting memory.
         const deps: Record<string, string[]> = { a: ["b"], b: ["a"] };
+        let searchCalls = 0;
         const manager = {
             packages: async () => Object.keys(deps).map((name) => ({ name, version: "1.0.0" })),
             packageJson: async (name: string) => ({
@@ -168,11 +171,15 @@ describe("cyclic package dependencies", () => {
                 version: "1.0.0",
                 dependencies: Object.fromEntries((deps[name] ?? []).map((d) => [d, "1.0.0"])),
             }),
-            search: async () => [],
+            search: async () => {
+                if (++searchCalls > 10) throw new Error("dependency walk did not terminate on cycle");
+                return [];
+            },
         } as unknown as Parameters<typeof registerFromManager>[0];
 
         const reg = await registerFromManager(manager, { focusedPackages: [{ name: "a", version: "1.0.0" }] });
 
+        expect(searchCalls).toBe(2); // each package scanned exactly once
         expect(reg.resolver["a#1.0.0"]).toBeDefined();
         expect(reg.resolver["b#1.0.0"]).toBeDefined();
     });

--- a/test/unit/typeschema/register.test.ts
+++ b/test/unit/typeschema/register.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import type { FHIRSchema } from "@atomic-ehr/fhirschema";
 import { type CanonicalUrl, enrichFHIRSchema, type Name } from "@root/typeschema/types";
-import { mergeFsElementProps, registerFromPackageMetas, resolveFsElementGenealogy } from "@typeschema/register";
+import {
+    mergeFsElementProps,
+    registerFromManager,
+    registerFromPackageMetas,
+    resolveFsElementGenealogy,
+} from "@typeschema/register";
 
 type PFS = Partial<FHIRSchema>;
 
@@ -148,5 +153,27 @@ describe("Register tests", async () => {
             min: 1,
             type: "string",
         });
+    });
+});
+
+describe("cyclic package dependencies", () => {
+    it("registerFromManager terminates on a dependency cycle", async () => {
+        // a ↔ b mutually depend (like hl7.terminology.r5 ↔ hl7.fhir.uv.extensions.r5).
+        // Without guarding the dependency walk this recurses until stack overflow / OOM.
+        const deps: Record<string, string[]> = { a: ["b"], b: ["a"] };
+        const manager = {
+            packages: async () => Object.keys(deps).map((name) => ({ name, version: "1.0.0" })),
+            packageJson: async (name: string) => ({
+                name,
+                version: "1.0.0",
+                dependencies: Object.fromEntries((deps[name] ?? []).map((d) => [d, "1.0.0"])),
+            }),
+            search: async () => [],
+        } as unknown as Parameters<typeof registerFromManager>[0];
+
+        const reg = await registerFromManager(manager, { focusedPackages: [{ name: "a", version: "1.0.0" }] });
+
+        expect(reg.resolver["a#1.0.0"]).toBeDefined();
+        expect(reg.resolver["b#1.0.0"]).toBeDefined();
     });
 });


### PR DESCRIPTION
## Problem

`mkPackageAwareResolver` (in `src/typeschema/register.ts`) walks each package's dependency tree recursively, memoizing the built index into `acc[pkgId]` only **after** recursing into dependencies. With mutually-dependent FHIR packages — e.g. `hl7.terminology.r5` ↔ `hl7.fhir.uv.extensions.r5` (pulled in transitively by the SQL-on-FHIR R5 closure) — the early-return guard (`if (acc[pkgId]) return acc[pkgId];`) never fires during the cycle, so resolution recurses forever, growing memory until the process is OOM-killed.

## Fix

- Memoize `acc[pkgId] = index;` **before** recursing into dependencies, so a cyclic dependency terminates at the guard instead of recursing forever.
- Remove the now-redundant post-recursion assignment.

```ts
const index = mkEmptyPkgIndex(pkg);
acc[pkgId] = index; // memoize before recursing — cycle terminates at the guard
for (const resource of await manager.search({ package: pkg })) {
    ...
}
```

## Memory consumption

Measured with `/usr/bin/time -l bun test test/api/write-generator/multi-package/sql-on-fhir.test.ts` (the multi-package test whose R5 closure contains the cyclic packages):

| | peak RSS | wall time | outcome |
|---|---|---|---|
| **before** (cyclic recursion) | **~7.2 GB** and climbing | never finishes (killed at 150 s) | runaway — OOM |
| **after** (this fix) | **~1.27 GB** | ~1.6 s | dependency walk completes |

The dependency walk now terminates and the resolver is built in bounded memory. (The SQL-on-FHIR test still reports assertion failures, but on a **pre-existing, unrelated** issue — `Base resource not found 'http://hl7.org/fhir/StructureDefinition/Library'` in the `org.sql-on-fhir.ig#2.1.0-pre` closure — which reproduces identically on published releases and is out of scope here.)

## Test

- Adds a regression test driving `registerFromManager` with a mock manager whose packages form an `a ↔ b` cycle. A cap on `manager.search()` calls plus an exact "each package scanned once" assertion make a reintroduced bug fail **fast and red** instead of slowly exhausting memory. Verified: passes with the fix, fails immediately without it.