### PR TITLE
API: fix SQL-on-FHIR generation by adding the missing hl7.fhir.r5.core dependency

### DIFF
--- a/examples/typescript-sql-on-fhir/generate.ts
+++ b/examples/typescript-sql-on-fhir/generate.ts
@@ -3,6 +3,9 @@ import { APIBuilder, prettyReport } from "../../src/api/builder";
 const builder = new APIBuilder()
     .throwException()
     .typescript({ withDebugComment: false, generateProfile: false })
+    // The IG references R5 core resources (e.g. ViewDefinition's base chain reaches Library)
+    // but doesn't declare an hl7.fhir.r5.core dependency, so add it explicitly to resolve them.
+    .fromPackage("hl7.fhir.r5.core", "5.0.0")
     .fromPackageRef("https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/package.tgz")
     .outputTo("./examples/typescript-sql-on-fhir/fhir-types")
     .introspection({ typeTree: "tree.yaml" })

--- a/test/api/write-generator/multi-package/sql-on-fhir.test.ts
+++ b/test/api/write-generator/multi-package/sql-on-fhir.test.ts
@@ -5,10 +5,13 @@ import { mkSilentLogger } from "@typeschema-test/utils";
 
 /**
  * Tests for SQL-on-FHIR package.
- * The SQL-on-FHIR package depends on hl7.fhir.r5.core.
+ * The IG targets FHIR R5 and references R5 core resources (e.g. the ViewDefinition base
+ * chain reaches `Library`), but its package does not declare an `hl7.fhir.r5.core`
+ * dependency — so we add it explicitly, otherwise those R5 bases fail to resolve.
  */
 describe("SQL-on-FHIR", async () => {
     const packageUrl = "https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/package.tgz";
+    const r5Core = { name: "hl7.fhir.r5.core", version: "5.0.0" };
 
     const treeShakeConfig = {
         "org.sql-on-fhir.ig": {
@@ -22,6 +25,7 @@ describe("SQL-on-FHIR", async () => {
 
     describe("TypeScript Generation", async () => {
         const result = await new APIBuilder({ logger: mkSilentLogger() })
+            .fromPackage(r5Core.name, r5Core.version)
             .fromPackageRef(packageUrl)
             .typeSchema({ treeShake: treeShakeConfig })
             .typescript({ inMemoryOnly: true })
@@ -57,6 +61,7 @@ describe("SQL-on-FHIR", async () => {
 
     describe("Python Generation", async () => {
         const result = await new APIBuilder({ logger: mkSilentLogger() })
+            .fromPackage(r5Core.name, r5Core.version)
             .fromPackageRef(packageUrl)
             .typeSchema({ treeShake: treeShakeConfig, promoteLogical: promoteLogicalConfig })
             .python({ inMemoryOnly: true })
@@ -87,6 +92,7 @@ describe("SQL-on-FHIR", async () => {
 
     describe("C# Generation", async () => {
         const result = await new APIBuilder({ logger: mkSilentLogger() })
+            .fromPackage(r5Core.name, r5Core.version)
             .fromPackageRef(packageUrl)
             .typeSchema({ treeShake: treeShakeConfig, promoteLogical: promoteLogicalConfig })
             .csharp({ inMemoryOnly: true })


### PR DESCRIPTION
## Problem

The `multi-package/sql-on-fhir` test was failing **0 / 12** with:

```
Code generation failed: Base resource not found 'http://hl7.org/fhir/StructureDefinition/Library'
  for <https://sql-on-fhir.org/ig/StructureDefinition/SQLQuery> from org.sql-on-fhir.ig#2.1.0-pre
```

Root cause (confirmed via https://get-ig.org/org.sql-on-fhir.ig): the SQL-on-FHIR IG targets FHIR R5 and references R5 *core* resources (the `ViewDefinition` base chain reaches `Library`), but the package only declares `hl7.terminology.r5` + `hl7.fhir.uv.extensions.r5` as dependencies — **not** `hl7.fhir.r5.core`. The current `build.fhir.org` build stopped pulling r5.core into the closure, so those R5 bases no longer resolve.

This is not a regression from any codegen change — it reproduces identically on published CM `0.0.24` and is purely an upstream packaging gap.

## Fix

Add `hl7.fhir.r5.core@5.0.0` explicitly to the SQL-on-FHIR generation config (test + example), so the IG's R5 bases resolve:

```typescript
new APIBuilder()
    .fromPackage("hl7.fhir.r5.core", "5.0.0")   // ← added
    .fromPackageRef("https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/package.tgz")
    .typeSchema({ treeShake: { "org.sql-on-fhir.ig": { ".../ViewDefinition": {} } } })
```

## Notes
- All existing assertions and snapshots are **unchanged** — adding the missing dependency restores the exact prior passing output (TS 45 r5 files, C# 5, Python `domain_resource.py`, etc.).
- The regenerated `typescript-sql-on-fhir` example output is byte-identical, so no generated files changed.
- Considered pinning to the stable `2.0.0` release instead, but its leaner `ViewDefinition` + `promoteLogical` emits **no** R5 dependency package for Python/C#, which would gut this test's multi-package coverage. Adding r5.core to the current build preserves it.

`test-multi-package` now passes 38 / 0.