### PR TITLE
PY: make python-us-core example mypy --strict clean (closes #181)

### DIFF
--- a/assets/api/writer-generator/python/profile_helpers.py
+++ b/assets/api/writer-generator/python/profile_helpers.py
@@ -55,7 +55,7 @@ def ensure_path(root: MutableMapping[str, Any], path: Sequence[str]) -> MutableM
             if not isinstance(nxt, MutableMapping):
                 nxt = {}
                 current[segment] = nxt
-            current = nxt  # type: ignore[assignment]
+            current = nxt
     return current
 
 
@@ -70,7 +70,7 @@ def merge_match(target: MutableMapping[str, Any], match: Mapping[str, Any]) -> N
         if is_record(match_value):
             existing = target.get(key)
             if is_record(existing):
-                merge_match(existing, match_value)  # type: ignore[arg-type]
+                merge_match(existing, match_value)
             else:
                 target[key] = dict(match_value)
         else:
@@ -146,7 +146,7 @@ def matches_value(value: Any, match: Any) -> bool:
                     return False
             return True
         return False
-    return value == match
+    return bool(value == match)
 
 
 def is_extension(value: Any, url: str | None = None) -> bool:
@@ -156,7 +156,7 @@ def is_extension(value: Any, url: str | None = None) -> bool:
     ext_url = _get_key(value, "url") if (is_record(value) or hasattr(value, "__dict__")) else None
     if ext_url is None:
         return False
-    return url is None or ext_url == url
+    return url is None or bool(ext_url == url)
 
 
 def get_extension_value(ext: Any | None, field: str) -> Any:
@@ -254,7 +254,7 @@ def unwrap_slice_choice(
         result.pop(key, None)
     variant_value = result.pop(choice_variant, None)
     if is_record(variant_value):
-        for k, v in variant_value.items():  # type: ignore[union-attr]
+        for k, v in variant_value.items():
             result[k] = v
     return result
 
@@ -276,7 +276,7 @@ def build_resource(resource_cls: type[T], /, **fields: Any) -> T:
     Centralises construction so generators don't need to import every model.
     """
     cleaned = {k: v for k, v in fields.items() if v is not None}
-    return resource_cls(**cleaned)  # type: ignore[call-arg]
+    return resource_cls(**cleaned)
 
 
 def ensure_profile(resource: Any, canonical_url: str) -> None:
@@ -311,8 +311,8 @@ def ensure_profile(resource: Any, canonical_url: str) -> None:
                     args = [a for a in ann.__args__ if a is not type(None)]
                     if args:
                         ann = args[0]
-                meta = ann(profile=[canonical_url])  # type: ignore[call-arg]
-                resource.meta = meta  # type: ignore[attr-defined]
+                meta = ann(profile=[canonical_url])
+                resource.meta = meta
                 return
             except Exception:
                 pass
@@ -320,7 +320,7 @@ def ensure_profile(resource: Any, canonical_url: str) -> None:
         return
     profiles = getattr(meta, "profile", None)
     if profiles is None:
-        meta.profile = [canonical_url]  # type: ignore[attr-defined]
+        meta.profile = [canonical_url]
     elif canonical_url not in profiles:
         profiles.append(canonical_url)
 

--- a/examples/python-us-core/fhir_types/example_folder_structures/profiles/__init__.py
+++ b/examples/python-us-core/fhir_types/example_folder_structures/profiles/__init__.py
@@ -3,3 +3,7 @@
 # Any manual changes made to this file may be overwritten.
 
 from .bundle_example_typed_bundle import ExampleTypedBundleProfile
+
+__all__ = [
+    'ExampleTypedBundleProfile',
+]

--- a/examples/python-us-core/fhir_types/example_folder_structures/profiles/bundle_example_typed_bundle.py
+++ b/examples/python-us-core/fhir_types/example_folder_structures/profiles/bundle_example_typed_bundle.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal, cast
 
 from fhir_types.hl7_fhir_r4_core.bundle import Bundle
 from fhir_types.hl7_fhir_r4_core.bundle import BundleEntry
@@ -25,8 +25,8 @@ class ExampleTypedBundleProfile:
 
     canonical_url: str = "http://example.org/fhir/StructureDefinition/ExampleTypedBundle"
 
-    _patient_entry_slice_match: dict = {"resource":{"resourceType":"Patient"}}
-    _organization_entry_slice_match: dict = {"resource":{"resourceType":"Organization"}}
+    _patient_entry_slice_match: dict[str, Any] = {"resource":{"resourceType":"Patient"}}
+    _organization_entry_slice_match: dict[str, Any] = {"resource":{"resourceType":"Organization"}}
 
     def __init__(self, resource: Bundle[Patient | Organization, Resource]) -> None:
         self._resource = resource
@@ -65,7 +65,7 @@ class ExampleTypedBundleProfile:
         return self._resource
 
     def get_type(self) -> Literal["document", "message", "transaction", "transaction-response", "batch", "batch-response", "history", "searchset", "collection"] | None:
-        return getattr(self._resource, "type", None)
+        return cast('Literal["document", "message", "transaction", "transaction-response", "batch", "batch-response", "history", "searchset", "collection"] | None', getattr(self._resource, "type", None))
 
     def set_type(self, value: Literal["document", "message", "transaction", "transaction-response", "batch", "batch-response", "history", "searchset", "collection"]) -> "ExampleTypedBundleProfile":
         setattr(self._resource, "type", value)
@@ -73,12 +73,12 @@ class ExampleTypedBundleProfile:
 
     def get_patient_entry(self, mode: str | None = None) -> BundleEntry[Patient] | None:
         match = self.__class__._patient_entry_slice_match
-        return get_array_slice(getattr(self._resource, "entry", None), match)
+        return cast('BundleEntry[Patient] | None', get_array_slice(getattr(self._resource, "entry", None), match))
 
     def get_organization_entry(self, mode: str | None = None) -> list[BundleEntry[Organization]] | None:
         match = self.__class__._organization_entry_slice_match
         result = get_array_slices(getattr(self._resource, "entry", None), match)
-        return result or None
+        return cast('list[BundleEntry[Organization]] | None', result or None)
 
     def set_patient_entry(self, value: BundleEntry[Patient] | None = None) -> "ExampleTypedBundleProfile":
         match = self.__class__._patient_entry_slice_match

--- a/examples/python-us-core/fhir_types/hl7_fhir_r4_core/profiles/__init__.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_r4_core/profiles/__init__.py
@@ -3,3 +3,7 @@
 # Any manual changes made to this file may be overwritten.
 
 from .observation_observation_vitalsigns import ObservationVitalsignsProfile
+
+__all__ = [
+    'ObservationVitalsignsProfile',
+]

--- a/examples/python-us-core/fhir_types/hl7_fhir_r4_core/profiles/observation_observation_vitalsigns.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_r4_core/profiles/observation_observation_vitalsigns.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.observation import Observation
 from fhir_types.hl7_fhir_r4_core.base import CodeableConcept, Period, Reference
@@ -23,7 +23,7 @@ class ObservationVitalsignsProfile:
 
     canonical_url: str = "http://hl7.org/fhir/StructureDefinition/vitalsigns"
 
-    _vscat_slice_match: dict = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
+    _vscat_slice_match: dict[str, Any] = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
 
     def __init__(self, resource: Observation) -> None:
         self._resource = resource
@@ -67,35 +67,35 @@ class ObservationVitalsignsProfile:
         return self._resource
 
     def get_status(self) -> Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None:
-        return getattr(self._resource, "status", None)
+        return cast('Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None', getattr(self._resource, "status", None))
 
     def set_status(self, value: Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]) -> "ObservationVitalsignsProfile":
         setattr(self._resource, "status", value)
         return self
 
     def get_code(self) -> CodeableConcept | None:
-        return getattr(self._resource, "code", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "code", None))
 
     def set_code(self, value: CodeableConcept) -> "ObservationVitalsignsProfile":
         setattr(self._resource, "code", value)
         return self
 
     def get_subject(self) -> Reference | None:
-        return getattr(self._resource, "subject", None)
+        return cast('Reference | None', getattr(self._resource, "subject", None))
 
     def set_subject(self, value: Reference) -> "ObservationVitalsignsProfile":
         setattr(self._resource, "subject", value)
         return self
 
     def get_category(self) -> list[CodeableConcept] | None:
-        return getattr(self._resource, "category", None)
+        return cast('list[CodeableConcept] | None', getattr(self._resource, "category", None))
 
     def set_category(self, value: list[CodeableConcept]) -> "ObservationVitalsignsProfile":
         setattr(self._resource, "category", value)
         return self
 
     def get_effective_date_time(self) -> str | None:
-        return getattr(self._resource, "effective_date_time", None)
+        return cast('str | None', getattr(self._resource, "effective_date_time", None))
 
     def set_effective_date_time(self, value: str) -> "ObservationVitalsignsProfile":
         setattr(self._resource, "effective_period", None)
@@ -103,7 +103,7 @@ class ObservationVitalsignsProfile:
         return self
 
     def get_effective_period(self) -> Period | None:
-        return getattr(self._resource, "effective_period", None)
+        return cast('Period | None', getattr(self._resource, "effective_period", None))
 
     def set_effective_period(self, value: Period) -> "ObservationVitalsignsProfile":
         setattr(self._resource, "effective_date_time", None)
@@ -111,18 +111,18 @@ class ObservationVitalsignsProfile:
         return self
 
     @overload
-    def get_vscat(self) -> dict | None: ...
+    def get_vscat(self) -> dict[str, Any] | None: ...
     @overload
     def get_vscat(self, mode: Literal["raw"]) -> CodeableConcept | None: ...
-    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict | CodeableConcept | None:
+    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | CodeableConcept | None:
         match = self.__class__._vscat_slice_match
         item = get_array_slice(getattr(self._resource, "category", None), match)
         if mode == "raw":
-            return item
+            return cast('CodeableConcept | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["coding"])
 
-    def set_vscat(self, value: dict | None = None) -> "ObservationVitalsignsProfile":
+    def set_vscat(self, value: dict[str, Any] | None = None) -> "ObservationVitalsignsProfile":
         match = self.__class__._vscat_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = CodeableConcept(**merged)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/__init__.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/__init__.py
@@ -11,3 +11,15 @@ from .patient_uscore_patient_profile import UscorePatientProfile
 from .extension_uscore_race_extension import UscoreRaceExtension
 from .extension_uscore_tribal_affiliation_extension import UscoreTribalAffiliationExtension
 from .observation_uscore_vital_signs_profile import UscoreVitalSignsProfile
+
+__all__ = [
+    'UscoreBloodPressureProfile',
+    'UscoreBodyWeightProfile',
+    'UscoreEthnicityExtension',
+    'UscoreIndividualSexExtension',
+    'UscoreInterpreterNeededExtension',
+    'UscorePatientProfile',
+    'UscoreRaceExtension',
+    'UscoreTribalAffiliationExtension',
+    'UscoreVitalSignsProfile',
+]

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_ethnicity_extension.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_ethnicity_extension.py
@@ -4,11 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.base import Extension
 from fhir_types.hl7_fhir_r4_core.base import Extension
-from fhir_types.hl7_fhir_r4_core.base import Coding
 from fhir_types.profile_helpers import (
     _get_key, apply_slice_match, build_resource, ensure_slice_defaults, get_array_slice, get_extension_value, \
     is_extension, matches_value, push_extension, set_array_slice, strip_match_keys, unwrap_slice_choice, validate_fixed_value, \
@@ -27,9 +26,9 @@ class UscoreEthnicityExtension:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
 
-    _omb_category_slice_match: dict = {"url":"ombCategory"}
-    _detailed_slice_match: dict = {"url":"detailed"}
-    _text_slice_match: dict = {"url":"text"}
+    _omb_category_slice_match: dict[str, Any] = {"url":"ombCategory"}
+    _detailed_slice_match: dict[str, Any] = {"url":"detailed"}
+    _text_slice_match: dict[str, Any] = {"url":"text"}
 
     def __init__(self, resource: Extension) -> None:
         self._resource = resource
@@ -60,24 +59,24 @@ class UscoreEthnicityExtension:
         return self._resource
 
     def get_extension(self) -> list[Extension] | None:
-        return getattr(self._resource, "extension", None)
+        return cast('list[Extension] | None', getattr(self._resource, "extension", None))
 
     def set_extension(self, value: list[Extension]) -> "UscoreEthnicityExtension":
         setattr(self._resource, "extension", value)
         return self
 
     def get_url(self) -> str | None:
-        return getattr(self._resource, "url", None)
+        return cast('str | None', getattr(self._resource, "url", None))
 
     def set_url(self, value: str) -> "UscoreEthnicityExtension":
         setattr(self._resource, "url", value)
         return self
 
     @overload
-    def get_omb_category(self) -> dict | None: ...
+    def get_omb_category(self) -> dict[str, Any] | None: ...
     @overload
     def get_omb_category(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_omb_category(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_omb_category(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "ombCategory")), None)
         if ext is None:
@@ -85,9 +84,9 @@ class UscoreEthnicityExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_omb_category(self, value: "Extension | dict") -> "UscoreEthnicityExtension":
+    def set_omb_category(self, value: "Extension | dict[str, Any]") -> "UscoreEthnicityExtension":
         if is_extension(value):
             if _get_key(value, "url") != "ombCategory":
                 raise ValueError(f"Expected extension url 'ombCategory', got {_get_key(value, 'url')!r}")
@@ -97,10 +96,10 @@ class UscoreEthnicityExtension:
         return self
 
     @overload
-    def get_detailed(self) -> dict | None: ...
+    def get_detailed(self) -> dict[str, Any] | None: ...
     @overload
     def get_detailed(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_detailed(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_detailed(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "detailed")), None)
         if ext is None:
@@ -108,9 +107,9 @@ class UscoreEthnicityExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_detailed(self, value: "Extension | dict") -> "UscoreEthnicityExtension":
+    def set_detailed(self, value: "Extension | dict[str, Any]") -> "UscoreEthnicityExtension":
         if is_extension(value):
             if _get_key(value, "url") != "detailed":
                 raise ValueError(f"Expected extension url 'detailed', got {_get_key(value, 'url')!r}")
@@ -120,10 +119,10 @@ class UscoreEthnicityExtension:
         return self
 
     @overload
-    def get_text(self) -> dict | None: ...
+    def get_text(self) -> dict[str, Any] | None: ...
     @overload
     def get_text(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_text(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_text(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "text")), None)
         if ext is None:
@@ -131,9 +130,9 @@ class UscoreEthnicityExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_text(self, value: "Extension | dict") -> "UscoreEthnicityExtension":
+    def set_text(self, value: "Extension | dict[str, Any]") -> "UscoreEthnicityExtension":
         if is_extension(value):
             if _get_key(value, "url") != "text":
                 raise ValueError(f"Expected extension url 'text', got {_get_key(value, 'url')!r}")
@@ -143,42 +142,42 @@ class UscoreEthnicityExtension:
         return self
 
     @overload
-    def get_extension_omb_category(self) -> Coding | None: ...
+    def get_extension_omb_category(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_omb_category(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_omb_category(self, mode: Literal["raw"] | None = None) -> Coding | Extension | None:
+    def get_extension_omb_category(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._omb_category_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["url"], "valueCoding")
 
     @overload
-    def get_extension_detailed(self) -> Coding | None: ...
+    def get_extension_detailed(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_detailed(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_detailed(self, mode: Literal["raw"] | None = None) -> Coding | Extension | None:
+    def get_extension_detailed(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._detailed_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["url"], "valueCoding")
 
     @overload
-    def get_extension_text(self) -> dict | None: ...
+    def get_extension_text(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_text(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_text(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_extension_text(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._text_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["url"])
 
-    def set_extension_omb_category(self, value: dict | None = None) -> "UscoreEthnicityExtension":
+    def set_extension_omb_category(self, value: dict[str, Any] | None = None) -> "UscoreEthnicityExtension":
         match = self.__class__._omb_category_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueCoding")
         merged = apply_slice_match(wrapped, match)
@@ -188,7 +187,7 @@ class UscoreEthnicityExtension:
         setattr(self._resource, "extension", items)
         return self
 
-    def set_extension_detailed(self, value: dict | None = None) -> "UscoreEthnicityExtension":
+    def set_extension_detailed(self, value: dict[str, Any] | None = None) -> "UscoreEthnicityExtension":
         match = self.__class__._detailed_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueCoding")
         merged = apply_slice_match(wrapped, match)
@@ -198,7 +197,7 @@ class UscoreEthnicityExtension:
         setattr(self._resource, "extension", items)
         return self
 
-    def set_extension_text(self, value: dict | None = None) -> "UscoreEthnicityExtension":
+    def set_extension_text(self, value: dict[str, Any] | None = None) -> "UscoreEthnicityExtension":
         match = self.__class__._text_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = Extension(**merged)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_individual_sex_extension.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_individual_sex_extension.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from fhir_types.hl7_fhir_r4_core.base import Extension
 from fhir_types.hl7_fhir_r4_core.base import Coding
 from fhir_types.profile_helpers import (
@@ -46,14 +48,14 @@ class UscoreIndividualSexExtension:
         return self._resource
 
     def get_value_coding(self) -> Coding | None:
-        return getattr(self._resource, "value_coding", None)
+        return cast('Coding | None', getattr(self._resource, "value_coding", None))
 
     def set_value_coding(self, value: Coding) -> "UscoreIndividualSexExtension":
         setattr(self._resource, "value_coding", value)
         return self
 
     def get_url(self) -> str | None:
-        return getattr(self._resource, "url", None)
+        return cast('str | None', getattr(self._resource, "url", None))
 
     def set_url(self, value: str) -> "UscoreIndividualSexExtension":
         setattr(self._resource, "url", value)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_interpreter_needed_extension.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_interpreter_needed_extension.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from fhir_types.hl7_fhir_r4_core.base import Extension
 from fhir_types.hl7_fhir_r4_core.base import Coding
 from fhir_types.profile_helpers import (
@@ -46,14 +48,14 @@ class UscoreInterpreterNeededExtension:
         return self._resource
 
     def get_value_coding(self) -> Coding | None:
-        return getattr(self._resource, "value_coding", None)
+        return cast('Coding | None', getattr(self._resource, "value_coding", None))
 
     def set_value_coding(self, value: Coding) -> "UscoreInterpreterNeededExtension":
         setattr(self._resource, "value_coding", value)
         return self
 
     def get_url(self) -> str | None:
-        return getattr(self._resource, "url", None)
+        return cast('str | None', getattr(self._resource, "url", None))
 
     def set_url(self, value: str) -> "UscoreInterpreterNeededExtension":
         setattr(self._resource, "url", value)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_race_extension.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_race_extension.py
@@ -4,11 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.base import Extension
 from fhir_types.hl7_fhir_r4_core.base import Extension
-from fhir_types.hl7_fhir_r4_core.base import Coding
 from fhir_types.profile_helpers import (
     _get_key, apply_slice_match, build_resource, ensure_slice_defaults, get_array_slice, get_extension_value, \
     is_extension, matches_value, push_extension, set_array_slice, strip_match_keys, unwrap_slice_choice, validate_fixed_value, \
@@ -30,9 +29,9 @@ class UscoreRaceExtension:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
 
-    _omb_category_slice_match: dict = {"url":"ombCategory"}
-    _detailed_slice_match: dict = {"url":"detailed"}
-    _text_slice_match: dict = {"url":"text"}
+    _omb_category_slice_match: dict[str, Any] = {"url":"ombCategory"}
+    _detailed_slice_match: dict[str, Any] = {"url":"detailed"}
+    _text_slice_match: dict[str, Any] = {"url":"text"}
 
     def __init__(self, resource: Extension) -> None:
         self._resource = resource
@@ -63,24 +62,24 @@ class UscoreRaceExtension:
         return self._resource
 
     def get_extension(self) -> list[Extension] | None:
-        return getattr(self._resource, "extension", None)
+        return cast('list[Extension] | None', getattr(self._resource, "extension", None))
 
     def set_extension(self, value: list[Extension]) -> "UscoreRaceExtension":
         setattr(self._resource, "extension", value)
         return self
 
     def get_url(self) -> str | None:
-        return getattr(self._resource, "url", None)
+        return cast('str | None', getattr(self._resource, "url", None))
 
     def set_url(self, value: str) -> "UscoreRaceExtension":
         setattr(self._resource, "url", value)
         return self
 
     @overload
-    def get_omb_category(self) -> dict | None: ...
+    def get_omb_category(self) -> dict[str, Any] | None: ...
     @overload
     def get_omb_category(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_omb_category(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_omb_category(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "ombCategory")), None)
         if ext is None:
@@ -88,9 +87,9 @@ class UscoreRaceExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_omb_category(self, value: "Extension | dict") -> "UscoreRaceExtension":
+    def set_omb_category(self, value: "Extension | dict[str, Any]") -> "UscoreRaceExtension":
         if is_extension(value):
             if _get_key(value, "url") != "ombCategory":
                 raise ValueError(f"Expected extension url 'ombCategory', got {_get_key(value, 'url')!r}")
@@ -100,10 +99,10 @@ class UscoreRaceExtension:
         return self
 
     @overload
-    def get_detailed(self) -> dict | None: ...
+    def get_detailed(self) -> dict[str, Any] | None: ...
     @overload
     def get_detailed(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_detailed(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_detailed(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "detailed")), None)
         if ext is None:
@@ -111,9 +110,9 @@ class UscoreRaceExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_detailed(self, value: "Extension | dict") -> "UscoreRaceExtension":
+    def set_detailed(self, value: "Extension | dict[str, Any]") -> "UscoreRaceExtension":
         if is_extension(value):
             if _get_key(value, "url") != "detailed":
                 raise ValueError(f"Expected extension url 'detailed', got {_get_key(value, 'url')!r}")
@@ -123,10 +122,10 @@ class UscoreRaceExtension:
         return self
 
     @overload
-    def get_text(self) -> dict | None: ...
+    def get_text(self) -> dict[str, Any] | None: ...
     @overload
     def get_text(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_text(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_text(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "text")), None)
         if ext is None:
@@ -134,9 +133,9 @@ class UscoreRaceExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_text(self, value: "Extension | dict") -> "UscoreRaceExtension":
+    def set_text(self, value: "Extension | dict[str, Any]") -> "UscoreRaceExtension":
         if is_extension(value):
             if _get_key(value, "url") != "text":
                 raise ValueError(f"Expected extension url 'text', got {_get_key(value, 'url')!r}")
@@ -146,42 +145,42 @@ class UscoreRaceExtension:
         return self
 
     @overload
-    def get_extension_omb_category(self) -> Coding | None: ...
+    def get_extension_omb_category(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_omb_category(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_omb_category(self, mode: Literal["raw"] | None = None) -> Coding | Extension | None:
+    def get_extension_omb_category(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._omb_category_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["url"], "valueCoding")
 
     @overload
-    def get_extension_detailed(self) -> Coding | None: ...
+    def get_extension_detailed(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_detailed(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_detailed(self, mode: Literal["raw"] | None = None) -> Coding | Extension | None:
+    def get_extension_detailed(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._detailed_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["url"], "valueCoding")
 
     @overload
-    def get_extension_text(self) -> dict | None: ...
+    def get_extension_text(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_text(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_text(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_extension_text(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._text_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["url"])
 
-    def set_extension_omb_category(self, value: dict | None = None) -> "UscoreRaceExtension":
+    def set_extension_omb_category(self, value: dict[str, Any] | None = None) -> "UscoreRaceExtension":
         match = self.__class__._omb_category_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueCoding")
         merged = apply_slice_match(wrapped, match)
@@ -191,7 +190,7 @@ class UscoreRaceExtension:
         setattr(self._resource, "extension", items)
         return self
 
-    def set_extension_detailed(self, value: dict | None = None) -> "UscoreRaceExtension":
+    def set_extension_detailed(self, value: dict[str, Any] | None = None) -> "UscoreRaceExtension":
         match = self.__class__._detailed_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueCoding")
         merged = apply_slice_match(wrapped, match)
@@ -201,7 +200,7 @@ class UscoreRaceExtension:
         setattr(self._resource, "extension", items)
         return self
 
-    def set_extension_text(self, value: dict | None = None) -> "UscoreRaceExtension":
+    def set_extension_text(self, value: dict[str, Any] | None = None) -> "UscoreRaceExtension":
         match = self.__class__._text_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = Extension(**merged)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_tribal_affiliation_extension.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_tribal_affiliation_extension.py
@@ -4,11 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.base import Extension
 from fhir_types.hl7_fhir_r4_core.base import Extension
-from fhir_types.hl7_fhir_r4_core.base import CodeableConcept
 from fhir_types.profile_helpers import (
     _get_key, apply_slice_match, build_resource, ensure_slice_defaults, get_array_slice, get_extension_value, \
     is_extension, matches_value, push_extension, set_array_slice, strip_match_keys, unwrap_slice_choice, validate_fixed_value, \
@@ -24,8 +23,8 @@ class UscoreTribalAffiliationExtension:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation"
 
-    _tribal_affiliation_slice_match: dict = {"url":"tribalAffiliation"}
-    _is_enrolled_slice_match: dict = {"url":"isEnrolled"}
+    _tribal_affiliation_slice_match: dict[str, Any] = {"url":"tribalAffiliation"}
+    _is_enrolled_slice_match: dict[str, Any] = {"url":"isEnrolled"}
 
     def __init__(self, resource: Extension) -> None:
         self._resource = resource
@@ -56,24 +55,24 @@ class UscoreTribalAffiliationExtension:
         return self._resource
 
     def get_extension(self) -> list[Extension] | None:
-        return getattr(self._resource, "extension", None)
+        return cast('list[Extension] | None', getattr(self._resource, "extension", None))
 
     def set_extension(self, value: list[Extension]) -> "UscoreTribalAffiliationExtension":
         setattr(self._resource, "extension", value)
         return self
 
     def get_url(self) -> str | None:
-        return getattr(self._resource, "url", None)
+        return cast('str | None', getattr(self._resource, "url", None))
 
     def set_url(self, value: str) -> "UscoreTribalAffiliationExtension":
         setattr(self._resource, "url", value)
         return self
 
     @overload
-    def get_tribal_affiliation(self) -> dict | None: ...
+    def get_tribal_affiliation(self) -> dict[str, Any] | None: ...
     @overload
     def get_tribal_affiliation(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_tribal_affiliation(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_tribal_affiliation(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "tribalAffiliation")), None)
         if ext is None:
@@ -81,9 +80,9 @@ class UscoreTribalAffiliationExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_tribal_affiliation(self, value: "Extension | dict") -> "UscoreTribalAffiliationExtension":
+    def set_tribal_affiliation(self, value: "Extension | dict[str, Any]") -> "UscoreTribalAffiliationExtension":
         if is_extension(value):
             if _get_key(value, "url") != "tribalAffiliation":
                 raise ValueError(f"Expected extension url 'tribalAffiliation', got {_get_key(value, 'url')!r}")
@@ -93,10 +92,10 @@ class UscoreTribalAffiliationExtension:
         return self
 
     @overload
-    def get_is_enrolled(self) -> dict | None: ...
+    def get_is_enrolled(self) -> dict[str, Any] | None: ...
     @overload
     def get_is_enrolled(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_is_enrolled(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_is_enrolled(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "isEnrolled")), None)
         if ext is None:
@@ -104,9 +103,9 @@ class UscoreTribalAffiliationExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_is_enrolled(self, value: "Extension | dict") -> "UscoreTribalAffiliationExtension":
+    def set_is_enrolled(self, value: "Extension | dict[str, Any]") -> "UscoreTribalAffiliationExtension":
         if is_extension(value):
             if _get_key(value, "url") != "isEnrolled":
                 raise ValueError(f"Expected extension url 'isEnrolled', got {_get_key(value, 'url')!r}")
@@ -116,30 +115,30 @@ class UscoreTribalAffiliationExtension:
         return self
 
     @overload
-    def get_extension_tribal_affiliation(self) -> CodeableConcept | None: ...
+    def get_extension_tribal_affiliation(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_tribal_affiliation(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_tribal_affiliation(self, mode: Literal["raw"] | None = None) -> CodeableConcept | Extension | None:
+    def get_extension_tribal_affiliation(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._tribal_affiliation_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["url"], "valueCodeableConcept")
 
     @overload
-    def get_extension_is_enrolled(self) -> dict | None: ...
+    def get_extension_is_enrolled(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_is_enrolled(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_is_enrolled(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_extension_is_enrolled(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._is_enrolled_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["url"])
 
-    def set_extension_tribal_affiliation(self, value: dict | None = None) -> "UscoreTribalAffiliationExtension":
+    def set_extension_tribal_affiliation(self, value: dict[str, Any] | None = None) -> "UscoreTribalAffiliationExtension":
         match = self.__class__._tribal_affiliation_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueCodeableConcept")
         merged = apply_slice_match(wrapped, match)
@@ -149,7 +148,7 @@ class UscoreTribalAffiliationExtension:
         setattr(self._resource, "extension", items)
         return self
 
-    def set_extension_is_enrolled(self, value: dict | None = None) -> "UscoreTribalAffiliationExtension":
+    def set_extension_is_enrolled(self, value: dict[str, Any] | None = None) -> "UscoreTribalAffiliationExtension":
         match = self.__class__._is_enrolled_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = Extension(**merged)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/observation_uscore_blood_pressure_profile.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/observation_uscore_blood_pressure_profile.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.observation import Observation
 from fhir_types.hl7_fhir_r4_core.base import (
@@ -26,9 +26,9 @@ class UscoreBloodPressureProfile:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
 
-    _vscat_slice_match: dict = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
-    _systolic_slice_match: dict = {"code":{"coding":[{"system":"http://loinc.org","code":"8480-6"}]}}
-    _diastolic_slice_match: dict = {"code":{"coding":[{"system":"http://loinc.org","code":"8462-4"}]}}
+    _vscat_slice_match: dict[str, Any] = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
+    _systolic_slice_match: dict[str, Any] = {"code":{"coding":[{"system":"http://loinc.org","code":"8480-6"}]}}
+    _diastolic_slice_match: dict[str, Any] = {"code":{"coding":[{"system":"http://loinc.org","code":"8462-4"}]}}
 
     def __init__(self, resource: Observation) -> None:
         self._resource = resource
@@ -78,42 +78,42 @@ class UscoreBloodPressureProfile:
         return self._resource
 
     def get_status(self) -> Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None:
-        return getattr(self._resource, "status", None)
+        return cast('Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None', getattr(self._resource, "status", None))
 
     def set_status(self, value: Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "status", value)
         return self
 
     def get_subject(self) -> Reference | None:
-        return getattr(self._resource, "subject", None)
+        return cast('Reference | None', getattr(self._resource, "subject", None))
 
     def set_subject(self, value: Reference) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "subject", value)
         return self
 
     def get_category(self) -> list[CodeableConcept] | None:
-        return getattr(self._resource, "category", None)
+        return cast('list[CodeableConcept] | None', getattr(self._resource, "category", None))
 
     def set_category(self, value: list[CodeableConcept]) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "category", value)
         return self
 
     def get_code(self) -> CodeableConcept | None:
-        return getattr(self._resource, "code", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "code", None))
 
     def set_code(self, value: CodeableConcept) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "code", value)
         return self
 
     def get_component(self) -> list[BackboneElement] | None:
-        return getattr(self._resource, "component", None)
+        return cast('list[BackboneElement] | None', getattr(self._resource, "component", None))
 
     def set_component(self, value: list[BackboneElement]) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "component", value)
         return self
 
     def get_effective_date_time(self) -> str | None:
-        return getattr(self._resource, "effective_date_time", None)
+        return cast('str | None', getattr(self._resource, "effective_date_time", None))
 
     def set_effective_date_time(self, value: str) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "effective_period", None)
@@ -121,7 +121,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_effective_period(self) -> Period | None:
-        return getattr(self._resource, "effective_period", None)
+        return cast('Period | None', getattr(self._resource, "effective_period", None))
 
     def set_effective_period(self, value: Period) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "effective_date_time", None)
@@ -129,7 +129,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_quantity(self) -> Quantity | None:
-        return getattr(self._resource, "value_quantity", None)
+        return cast('Quantity | None', getattr(self._resource, "value_quantity", None))
 
     def set_value_quantity(self, value: Quantity) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_codeable_concept", None)
@@ -146,7 +146,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_codeable_concept(self) -> CodeableConcept | None:
-        return getattr(self._resource, "value_codeable_concept", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "value_codeable_concept", None))
 
     def set_value_codeable_concept(self, value: CodeableConcept) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -163,7 +163,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_string(self) -> str | None:
-        return getattr(self._resource, "value_string", None)
+        return cast('str | None', getattr(self._resource, "value_string", None))
 
     def set_value_string(self, value: str) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -180,7 +180,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_boolean(self) -> bool | None:
-        return getattr(self._resource, "value_boolean", None)
+        return cast('bool | None', getattr(self._resource, "value_boolean", None))
 
     def set_value_boolean(self, value: bool) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -197,7 +197,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_integer(self) -> int | None:
-        return getattr(self._resource, "value_integer", None)
+        return cast('int | None', getattr(self._resource, "value_integer", None))
 
     def set_value_integer(self, value: int) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -214,7 +214,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_range(self) -> Range | None:
-        return getattr(self._resource, "value_range", None)
+        return cast('Range | None', getattr(self._resource, "value_range", None))
 
     def set_value_range(self, value: Range) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -231,7 +231,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_ratio(self) -> Ratio | None:
-        return getattr(self._resource, "value_ratio", None)
+        return cast('Ratio | None', getattr(self._resource, "value_ratio", None))
 
     def set_value_ratio(self, value: Ratio) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -248,7 +248,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_sampled_data(self) -> SampledData | None:
-        return getattr(self._resource, "value_sampled_data", None)
+        return cast('SampledData | None', getattr(self._resource, "value_sampled_data", None))
 
     def set_value_sampled_data(self, value: SampledData) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -265,7 +265,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_time(self) -> str | None:
-        return getattr(self._resource, "value_time", None)
+        return cast('str | None', getattr(self._resource, "value_time", None))
 
     def set_value_time(self, value: str) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -282,7 +282,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_date_time(self) -> str | None:
-        return getattr(self._resource, "value_date_time", None)
+        return cast('str | None', getattr(self._resource, "value_date_time", None))
 
     def set_value_date_time(self, value: str) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -299,7 +299,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_period(self) -> Period | None:
-        return getattr(self._resource, "value_period", None)
+        return cast('Period | None', getattr(self._resource, "value_period", None))
 
     def set_value_period(self, value: Period) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -316,42 +316,42 @@ class UscoreBloodPressureProfile:
         return self
 
     @overload
-    def get_vscat(self) -> dict | None: ...
+    def get_vscat(self) -> dict[str, Any] | None: ...
     @overload
     def get_vscat(self, mode: Literal["raw"]) -> CodeableConcept | None: ...
-    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict | CodeableConcept | None:
+    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | CodeableConcept | None:
         match = self.__class__._vscat_slice_match
         item = get_array_slice(getattr(self._resource, "category", None), match)
         if mode == "raw":
-            return item
+            return cast('CodeableConcept | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["coding"])
 
     @overload
-    def get_systolic(self) -> Quantity | None: ...
+    def get_systolic(self) -> dict[str, Any] | None: ...
     @overload
     def get_systolic(self, mode: Literal["raw"]) -> ObservationComponent | None: ...
-    def get_systolic(self, mode: Literal["raw"] | None = None) -> Quantity | ObservationComponent | None:
+    def get_systolic(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | ObservationComponent | None:
         match = self.__class__._systolic_slice_match
         item = get_array_slice(getattr(self._resource, "component", None), match)
         if mode == "raw":
-            return item
+            return cast('ObservationComponent | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["code"], "valueQuantity")
 
     @overload
-    def get_diastolic(self) -> Quantity | None: ...
+    def get_diastolic(self) -> dict[str, Any] | None: ...
     @overload
     def get_diastolic(self, mode: Literal["raw"]) -> ObservationComponent | None: ...
-    def get_diastolic(self, mode: Literal["raw"] | None = None) -> Quantity | ObservationComponent | None:
+    def get_diastolic(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | ObservationComponent | None:
         match = self.__class__._diastolic_slice_match
         item = get_array_slice(getattr(self._resource, "component", None), match)
         if mode == "raw":
-            return item
+            return cast('ObservationComponent | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["code"], "valueQuantity")
 
-    def set_vscat(self, value: dict | None = None) -> "UscoreBloodPressureProfile":
+    def set_vscat(self, value: dict[str, Any] | None = None) -> "UscoreBloodPressureProfile":
         match = self.__class__._vscat_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = CodeableConcept(**merged)
@@ -360,7 +360,7 @@ class UscoreBloodPressureProfile:
         setattr(self._resource, "category", items)
         return self
 
-    def set_systolic(self, value: dict | None = None) -> "UscoreBloodPressureProfile":
+    def set_systolic(self, value: dict[str, Any] | None = None) -> "UscoreBloodPressureProfile":
         match = self.__class__._systolic_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueQuantity")
         merged = apply_slice_match(wrapped, match)
@@ -370,7 +370,7 @@ class UscoreBloodPressureProfile:
         setattr(self._resource, "component", items)
         return self
 
-    def set_diastolic(self, value: dict | None = None) -> "UscoreBloodPressureProfile":
+    def set_diastolic(self, value: dict[str, Any] | None = None) -> "UscoreBloodPressureProfile":
         match = self.__class__._diastolic_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueQuantity")
         merged = apply_slice_match(wrapped, match)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/observation_uscore_body_weight_profile.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/observation_uscore_body_weight_profile.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.observation import Observation
 from fhir_types.hl7_fhir_r4_core.base import (
@@ -25,7 +25,7 @@ class UscoreBodyWeightProfile:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight"
 
-    _vscat_slice_match: dict = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
+    _vscat_slice_match: dict[str, Any] = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
 
     def __init__(self, resource: Observation) -> None:
         self._resource = resource
@@ -69,35 +69,35 @@ class UscoreBodyWeightProfile:
         return self._resource
 
     def get_status(self) -> Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None:
-        return getattr(self._resource, "status", None)
+        return cast('Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None', getattr(self._resource, "status", None))
 
     def set_status(self, value: Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "status", value)
         return self
 
     def get_subject(self) -> Reference | None:
-        return getattr(self._resource, "subject", None)
+        return cast('Reference | None', getattr(self._resource, "subject", None))
 
     def set_subject(self, value: Reference) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "subject", value)
         return self
 
     def get_category(self) -> list[CodeableConcept] | None:
-        return getattr(self._resource, "category", None)
+        return cast('list[CodeableConcept] | None', getattr(self._resource, "category", None))
 
     def set_category(self, value: list[CodeableConcept]) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "category", value)
         return self
 
     def get_code(self) -> CodeableConcept | None:
-        return getattr(self._resource, "code", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "code", None))
 
     def set_code(self, value: CodeableConcept) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "code", value)
         return self
 
     def get_effective_date_time(self) -> str | None:
-        return getattr(self._resource, "effective_date_time", None)
+        return cast('str | None', getattr(self._resource, "effective_date_time", None))
 
     def set_effective_date_time(self, value: str) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "effective_period", None)
@@ -105,7 +105,7 @@ class UscoreBodyWeightProfile:
         return self
 
     def get_effective_period(self) -> Period | None:
-        return getattr(self._resource, "effective_period", None)
+        return cast('Period | None', getattr(self._resource, "effective_period", None))
 
     def set_effective_period(self, value: Period) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "effective_date_time", None)
@@ -113,95 +113,95 @@ class UscoreBodyWeightProfile:
         return self
 
     def get_value_quantity(self) -> Quantity | None:
-        return getattr(self._resource, "value_quantity", None)
+        return cast('Quantity | None', getattr(self._resource, "value_quantity", None))
 
     def set_value_quantity(self, value: Quantity) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_quantity", value)
         return self
 
     def get_value_codeable_concept(self) -> CodeableConcept | None:
-        return getattr(self._resource, "value_codeable_concept", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "value_codeable_concept", None))
 
     def set_value_codeable_concept(self, value: CodeableConcept) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_codeable_concept", value)
         return self
 
     def get_value_string(self) -> str | None:
-        return getattr(self._resource, "value_string", None)
+        return cast('str | None', getattr(self._resource, "value_string", None))
 
     def set_value_string(self, value: str) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_string", value)
         return self
 
     def get_value_boolean(self) -> bool | None:
-        return getattr(self._resource, "value_boolean", None)
+        return cast('bool | None', getattr(self._resource, "value_boolean", None))
 
     def set_value_boolean(self, value: bool) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_boolean", value)
         return self
 
     def get_value_integer(self) -> int | None:
-        return getattr(self._resource, "value_integer", None)
+        return cast('int | None', getattr(self._resource, "value_integer", None))
 
     def set_value_integer(self, value: int) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_integer", value)
         return self
 
     def get_value_range(self) -> Range | None:
-        return getattr(self._resource, "value_range", None)
+        return cast('Range | None', getattr(self._resource, "value_range", None))
 
     def set_value_range(self, value: Range) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_range", value)
         return self
 
     def get_value_ratio(self) -> Ratio | None:
-        return getattr(self._resource, "value_ratio", None)
+        return cast('Ratio | None', getattr(self._resource, "value_ratio", None))
 
     def set_value_ratio(self, value: Ratio) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_ratio", value)
         return self
 
     def get_value_sampled_data(self) -> SampledData | None:
-        return getattr(self._resource, "value_sampled_data", None)
+        return cast('SampledData | None', getattr(self._resource, "value_sampled_data", None))
 
     def set_value_sampled_data(self, value: SampledData) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_sampled_data", value)
         return self
 
     def get_value_time(self) -> str | None:
-        return getattr(self._resource, "value_time", None)
+        return cast('str | None', getattr(self._resource, "value_time", None))
 
     def set_value_time(self, value: str) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_time", value)
         return self
 
     def get_value_date_time(self) -> str | None:
-        return getattr(self._resource, "value_date_time", None)
+        return cast('str | None', getattr(self._resource, "value_date_time", None))
 
     def set_value_date_time(self, value: str) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_date_time", value)
         return self
 
     def get_value_period(self) -> Period | None:
-        return getattr(self._resource, "value_period", None)
+        return cast('Period | None', getattr(self._resource, "value_period", None))
 
     def set_value_period(self, value: Period) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_period", value)
         return self
 
     @overload
-    def get_vscat(self) -> dict | None: ...
+    def get_vscat(self) -> dict[str, Any] | None: ...
     @overload
     def get_vscat(self, mode: Literal["raw"]) -> CodeableConcept | None: ...
-    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict | CodeableConcept | None:
+    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | CodeableConcept | None:
         match = self.__class__._vscat_slice_match
         item = get_array_slice(getattr(self._resource, "category", None), match)
         if mode == "raw":
-            return item
+            return cast('CodeableConcept | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["coding"])
 
-    def set_vscat(self, value: dict | None = None) -> "UscoreBodyWeightProfile":
+    def set_vscat(self, value: dict[str, Any] | None = None) -> "UscoreBodyWeightProfile":
         match = self.__class__._vscat_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = CodeableConcept(**merged)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/observation_uscore_vital_signs_profile.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/observation_uscore_vital_signs_profile.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.observation import Observation
 from fhir_types.hl7_fhir_r4_core.base import (
@@ -25,7 +25,7 @@ class UscoreVitalSignsProfile:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs"
 
-    _vscat_slice_match: dict = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
+    _vscat_slice_match: dict[str, Any] = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
 
     def __init__(self, resource: Observation) -> None:
         self._resource = resource
@@ -69,35 +69,35 @@ class UscoreVitalSignsProfile:
         return self._resource
 
     def get_status(self) -> Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None:
-        return getattr(self._resource, "status", None)
+        return cast('Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None', getattr(self._resource, "status", None))
 
     def set_status(self, value: Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "status", value)
         return self
 
     def get_code(self) -> CodeableConcept | None:
-        return getattr(self._resource, "code", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "code", None))
 
     def set_code(self, value: CodeableConcept) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "code", value)
         return self
 
     def get_subject(self) -> Reference | None:
-        return getattr(self._resource, "subject", None)
+        return cast('Reference | None', getattr(self._resource, "subject", None))
 
     def set_subject(self, value: Reference) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "subject", value)
         return self
 
     def get_category(self) -> list[CodeableConcept] | None:
-        return getattr(self._resource, "category", None)
+        return cast('list[CodeableConcept] | None', getattr(self._resource, "category", None))
 
     def set_category(self, value: list[CodeableConcept]) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "category", value)
         return self
 
     def get_effective_date_time(self) -> str | None:
-        return getattr(self._resource, "effective_date_time", None)
+        return cast('str | None', getattr(self._resource, "effective_date_time", None))
 
     def set_effective_date_time(self, value: str) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "effective_period", None)
@@ -105,7 +105,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_effective_period(self) -> Period | None:
-        return getattr(self._resource, "effective_period", None)
+        return cast('Period | None', getattr(self._resource, "effective_period", None))
 
     def set_effective_period(self, value: Period) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "effective_date_time", None)
@@ -113,7 +113,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_quantity(self) -> Quantity | None:
-        return getattr(self._resource, "value_quantity", None)
+        return cast('Quantity | None', getattr(self._resource, "value_quantity", None))
 
     def set_value_quantity(self, value: Quantity) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_codeable_concept", None)
@@ -130,7 +130,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_codeable_concept(self) -> CodeableConcept | None:
-        return getattr(self._resource, "value_codeable_concept", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "value_codeable_concept", None))
 
     def set_value_codeable_concept(self, value: CodeableConcept) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -147,7 +147,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_string(self) -> str | None:
-        return getattr(self._resource, "value_string", None)
+        return cast('str | None', getattr(self._resource, "value_string", None))
 
     def set_value_string(self, value: str) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -164,7 +164,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_boolean(self) -> bool | None:
-        return getattr(self._resource, "value_boolean", None)
+        return cast('bool | None', getattr(self._resource, "value_boolean", None))
 
     def set_value_boolean(self, value: bool) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -181,7 +181,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_integer(self) -> int | None:
-        return getattr(self._resource, "value_integer", None)
+        return cast('int | None', getattr(self._resource, "value_integer", None))
 
     def set_value_integer(self, value: int) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -198,7 +198,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_range(self) -> Range | None:
-        return getattr(self._resource, "value_range", None)
+        return cast('Range | None', getattr(self._resource, "value_range", None))
 
     def set_value_range(self, value: Range) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -215,7 +215,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_ratio(self) -> Ratio | None:
-        return getattr(self._resource, "value_ratio", None)
+        return cast('Ratio | None', getattr(self._resource, "value_ratio", None))
 
     def set_value_ratio(self, value: Ratio) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -232,7 +232,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_sampled_data(self) -> SampledData | None:
-        return getattr(self._resource, "value_sampled_data", None)
+        return cast('SampledData | None', getattr(self._resource, "value_sampled_data", None))
 
     def set_value_sampled_data(self, value: SampledData) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -249,7 +249,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_time(self) -> str | None:
-        return getattr(self._resource, "value_time", None)
+        return cast('str | None', getattr(self._resource, "value_time", None))
 
     def set_value_time(self, value: str) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -266,7 +266,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_date_time(self) -> str | None:
-        return getattr(self._resource, "value_date_time", None)
+        return cast('str | None', getattr(self._resource, "value_date_time", None))
 
     def set_value_date_time(self, value: str) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -283,7 +283,7 @@ class UscoreVitalSignsProfile:
         return self
 
     def get_value_period(self) -> Period | None:
-        return getattr(self._resource, "value_period", None)
+        return cast('Period | None', getattr(self._resource, "value_period", None))
 
     def set_value_period(self, value: Period) -> "UscoreVitalSignsProfile":
         setattr(self._resource, "value_quantity", None)
@@ -300,18 +300,18 @@ class UscoreVitalSignsProfile:
         return self
 
     @overload
-    def get_vscat(self) -> dict | None: ...
+    def get_vscat(self) -> dict[str, Any] | None: ...
     @overload
     def get_vscat(self, mode: Literal["raw"]) -> CodeableConcept | None: ...
-    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict | CodeableConcept | None:
+    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | CodeableConcept | None:
         match = self.__class__._vscat_slice_match
         item = get_array_slice(getattr(self._resource, "category", None), match)
         if mode == "raw":
-            return item
+            return cast('CodeableConcept | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["coding"])
 
-    def set_vscat(self, value: dict | None = None) -> "UscoreVitalSignsProfile":
+    def set_vscat(self, value: dict[str, Any] | None = None) -> "UscoreVitalSignsProfile":
         match = self.__class__._vscat_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = CodeableConcept(**merged)

--- a/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/patient_uscore_patient_profile.py
+++ b/examples/python-us-core/fhir_types/hl7_fhir_us_core/profiles/patient_uscore_patient_profile.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.patient import Patient
 from fhir_types.hl7_fhir_r4_core.base import Extension
@@ -66,26 +66,26 @@ class UscorePatientProfile:
         return self._resource
 
     def get_identifier(self) -> list[Identifier] | None:
-        return getattr(self._resource, "identifier", None)
+        return cast('list[Identifier] | None', getattr(self._resource, "identifier", None))
 
     def set_identifier(self, value: list[Identifier]) -> "UscorePatientProfile":
         setattr(self._resource, "identifier", value)
         return self
 
     def get_name(self) -> list[HumanName] | None:
-        return getattr(self._resource, "name", None)
+        return cast('list[HumanName] | None', getattr(self._resource, "name", None))
 
     def set_name(self, value: list[HumanName]) -> "UscorePatientProfile":
         setattr(self._resource, "name", value)
         return self
 
     @overload
-    def get_race(self) -> dict | None: ...
+    def get_race(self) -> dict[str, Any] | None: ...
     @overload
     def get_race(self, mode: Literal["raw"]) -> Extension | None: ...
     @overload
     def get_race(self, mode: Literal["profile"]) -> UscoreRaceExtension | None: ...
-    def get_race(self, mode: Literal["raw", "profile"] | None = None) -> dict | Extension | UscoreRaceExtension | None:
+    def get_race(self, mode: Literal["raw", "profile"] | None = None) -> dict[str, Any] | Extension | UscoreRaceExtension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race")), None)
         if ext is None:
@@ -98,7 +98,7 @@ class UscorePatientProfile:
         config = [{"name": "ombCategory", "valueField": "value_coding", "isArray": False}, {"name": "detailed", "valueField": "value_coding", "isArray": True}, {"name": "text", "valueField": "value_string", "isArray": False}]
         return extract_complex_extension(ext, config)
 
-    def set_race(self, value: "UscoreRaceExtension | Extension | dict") -> "UscorePatientProfile":
+    def set_race(self, value: "UscoreRaceExtension | Extension | dict[str, Any]") -> "UscorePatientProfile":
         if isinstance(value, UscoreRaceExtension):
             push_extension(self._resource, value.to_resource())
         elif is_extension(value):
@@ -117,12 +117,12 @@ class UscorePatientProfile:
         return self
 
     @overload
-    def get_ethnicity(self) -> dict | None: ...
+    def get_ethnicity(self) -> dict[str, Any] | None: ...
     @overload
     def get_ethnicity(self, mode: Literal["raw"]) -> Extension | None: ...
     @overload
     def get_ethnicity(self, mode: Literal["profile"]) -> UscoreEthnicityExtension | None: ...
-    def get_ethnicity(self, mode: Literal["raw", "profile"] | None = None) -> dict | Extension | UscoreEthnicityExtension | None:
+    def get_ethnicity(self, mode: Literal["raw", "profile"] | None = None) -> dict[str, Any] | Extension | UscoreEthnicityExtension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity")), None)
         if ext is None:
@@ -135,7 +135,7 @@ class UscorePatientProfile:
         config = [{"name": "ombCategory", "valueField": "value_coding", "isArray": False}, {"name": "detailed", "valueField": "value_coding", "isArray": True}, {"name": "text", "valueField": "value_string", "isArray": False}]
         return extract_complex_extension(ext, config)
 
-    def set_ethnicity(self, value: "UscoreEthnicityExtension | Extension | dict") -> "UscorePatientProfile":
+    def set_ethnicity(self, value: "UscoreEthnicityExtension | Extension | dict[str, Any]") -> "UscorePatientProfile":
         if isinstance(value, UscoreEthnicityExtension):
             push_extension(self._resource, value.to_resource())
         elif is_extension(value):
@@ -154,12 +154,12 @@ class UscorePatientProfile:
         return self
 
     @overload
-    def get_tribal_affiliation(self) -> dict | None: ...
+    def get_tribal_affiliation(self) -> dict[str, Any] | None: ...
     @overload
     def get_tribal_affiliation(self, mode: Literal["raw"]) -> Extension | None: ...
     @overload
     def get_tribal_affiliation(self, mode: Literal["profile"]) -> UscoreTribalAffiliationExtension | None: ...
-    def get_tribal_affiliation(self, mode: Literal["raw", "profile"] | None = None) -> dict | Extension | UscoreTribalAffiliationExtension | None:
+    def get_tribal_affiliation(self, mode: Literal["raw", "profile"] | None = None) -> dict[str, Any] | Extension | UscoreTribalAffiliationExtension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation")), None)
         if ext is None:
@@ -172,7 +172,7 @@ class UscorePatientProfile:
         config = [{"name": "tribalAffiliation", "valueField": "value_codeable_concept", "isArray": False}, {"name": "isEnrolled", "valueField": "value_boolean", "isArray": False}]
         return extract_complex_extension(ext, config)
 
-    def set_tribal_affiliation(self, value: "UscoreTribalAffiliationExtension | Extension | dict") -> "UscorePatientProfile":
+    def set_tribal_affiliation(self, value: "UscoreTribalAffiliationExtension | Extension | dict[str, Any]") -> "UscorePatientProfile":
         if isinstance(value, UscoreTribalAffiliationExtension):
             push_extension(self._resource, value.to_resource())
         elif is_extension(value):
@@ -204,7 +204,7 @@ class UscorePatientProfile:
             return ext_obj
         if mode == "profile":
             return UscoreIndividualSexExtension.apply(ext_obj)
-        return get_extension_value(ext, "value_coding")
+        return cast('Coding | None', get_extension_value(ext, "value_coding"))
 
     def set_sex(self, value: "UscoreIndividualSexExtension | Extension | Any") -> "UscorePatientProfile":
         if isinstance(value, UscoreIndividualSexExtension):
@@ -233,7 +233,7 @@ class UscorePatientProfile:
             return ext_obj
         if mode == "profile":
             return UscoreInterpreterNeededExtension.apply(ext_obj)
-        return get_extension_value(ext, "value_coding")
+        return cast('Coding | None', get_extension_value(ext, "value_coding"))
 
     def set_interpreter_required(self, value: "UscoreInterpreterNeededExtension | Extension | Any") -> "UscorePatientProfile":
         if isinstance(value, UscoreInterpreterNeededExtension):

--- a/examples/python-us-core/fhir_types/profile_helpers.py
+++ b/examples/python-us-core/fhir_types/profile_helpers.py
@@ -55,7 +55,7 @@ def ensure_path(root: MutableMapping[str, Any], path: Sequence[str]) -> MutableM
             if not isinstance(nxt, MutableMapping):
                 nxt = {}
                 current[segment] = nxt
-            current = nxt  # type: ignore[assignment]
+            current = nxt
     return current
 
 
@@ -70,7 +70,7 @@ def merge_match(target: MutableMapping[str, Any], match: Mapping[str, Any]) -> N
         if is_record(match_value):
             existing = target.get(key)
             if is_record(existing):
-                merge_match(existing, match_value)  # type: ignore[arg-type]
+                merge_match(existing, match_value)
             else:
                 target[key] = dict(match_value)
         else:
@@ -146,7 +146,7 @@ def matches_value(value: Any, match: Any) -> bool:
                     return False
             return True
         return False
-    return value == match
+    return bool(value == match)
 
 
 def is_extension(value: Any, url: str | None = None) -> bool:
@@ -156,7 +156,7 @@ def is_extension(value: Any, url: str | None = None) -> bool:
     ext_url = _get_key(value, "url") if (is_record(value) or hasattr(value, "__dict__")) else None
     if ext_url is None:
         return False
-    return url is None or ext_url == url
+    return url is None or bool(ext_url == url)
 
 
 def get_extension_value(ext: Any | None, field: str) -> Any:
@@ -254,7 +254,7 @@ def unwrap_slice_choice(
         result.pop(key, None)
     variant_value = result.pop(choice_variant, None)
     if is_record(variant_value):
-        for k, v in variant_value.items():  # type: ignore[union-attr]
+        for k, v in variant_value.items():
             result[k] = v
     return result
 
@@ -276,7 +276,7 @@ def build_resource(resource_cls: type[T], /, **fields: Any) -> T:
     Centralises construction so generators don't need to import every model.
     """
     cleaned = {k: v for k, v in fields.items() if v is not None}
-    return resource_cls(**cleaned)  # type: ignore[call-arg]
+    return resource_cls(**cleaned)
 
 
 def ensure_profile(resource: Any, canonical_url: str) -> None:
@@ -311,8 +311,8 @@ def ensure_profile(resource: Any, canonical_url: str) -> None:
                     args = [a for a in ann.__args__ if a is not type(None)]
                     if args:
                         ann = args[0]
-                meta = ann(profile=[canonical_url])  # type: ignore[call-arg]
-                resource.meta = meta  # type: ignore[attr-defined]
+                meta = ann(profile=[canonical_url])
+                resource.meta = meta
                 return
             except Exception:
                 pass
@@ -320,7 +320,7 @@ def ensure_profile(resource: Any, canonical_url: str) -> None:
         return
     profiles = getattr(meta, "profile", None)
     if profiles is None:
-        meta.profile = [canonical_url]  # type: ignore[attr-defined]
+        meta.profile = [canonical_url]
     elif canonical_url not in profiles:
         profiles.append(canonical_url)
 

--- a/examples/python-us-core/mypy.ini
+++ b/examples/python-us-core/mypy.ini
@@ -1,14 +1,10 @@
 [mypy]
 python_version = 3.13
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-check_untyped_defs = True
-disallow_untyped_decorators = False
-no_implicit_optional = True
+strict = True
+# FHIR resources are modelled as Pydantic objects that also accept/return plain
+# dicts, and the demo/test code freely accesses optional fields it knows are set.
+# Optional-aware checks and these codes are impractical to satisfy without
+# pervasive asserts, so they stay relaxed even under strict.
 strict_optional = False
-warn_redundant_casts = False
-warn_unused_ignores = False
-warn_return_any = False
-warn_unreachable = False
 disable_error_code = assignment, return-value, union-attr, dict-item, index
 plugins = pydantic.mypy

--- a/examples/python-us-core/test_profile_bodyweight.py
+++ b/examples/python-us-core/test_profile_bodyweight.py
@@ -9,7 +9,7 @@ import warnings
 import pytest
 from fhir_types.hl7_fhir_r4_core.base import CodeableConcept, Coding, Quantity, Reference
 from fhir_types.hl7_fhir_r4_core.observation import Observation
-from fhir_types.hl7_fhir_r4_core.resource import Meta
+from fhir_types.hl7_fhir_r4_core.base import Meta
 from fhir_types.hl7_fhir_us_core.profiles.observation_uscore_body_weight_profile import UscoreBodyWeightProfile
 
 # Pydantic warns when extensions list contains plain dicts instead of Extension
@@ -20,7 +20,7 @@ warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
 CANONICAL_URL = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight"
 
 
-def test_import_profiled_observation_from_api_and_read_values():
+def test_import_profiled_observation_from_api_and_read_values() -> None:
     api_response = Observation(
         resource_type="Observation",
         meta=Meta(profile=[CANONICAL_URL]),
@@ -44,7 +44,7 @@ def test_import_profiled_observation_from_api_and_read_values():
     assert profile.get_subject().reference == "Patient/pt-1"
 
 
-def test_apply_profile_to_bare_observation_and_populate_it():
+def test_apply_profile_to_bare_observation_and_populate_it() -> None:
     bare_observation = Observation(resource_type="Observation", status="preliminary", code=CodeableConcept())
     profile = UscoreBodyWeightProfile.apply(bare_observation)
 
@@ -59,7 +59,7 @@ def test_apply_profile_to_bare_observation_and_populate_it():
     assert CANONICAL_URL in profile.to_resource().meta.profile
 
 
-def test_create_builds_a_resource_with_fixed_code_and_required_slice_stubs():
+def test_create_builds_a_resource_with_fixed_code_and_required_slice_stubs() -> None:
     profile = UscoreBodyWeightProfile.create(
         status="final",
         subject=Reference(reference="Patient/example"),
@@ -75,7 +75,7 @@ def test_create_builds_a_resource_with_fixed_code_and_required_slice_stubs():
     assert profile.validate()["errors"] == []
 
 
-def test_validate_catches_disallowed_value_variants_on_raw_resource():
+def test_validate_catches_disallowed_value_variants_on_raw_resource() -> None:
     resource = Observation(
         resource_type="Observation",
         meta=Meta(profile=[CANONICAL_URL]),
@@ -96,7 +96,7 @@ def test_validate_catches_disallowed_value_variants_on_raw_resource():
     assert "UscoreBodyWeightProfile: field 'value_string' must not be present" in errors
 
 
-def test_get_vscat_returns_flat_value():
+def test_get_vscat_returns_flat_value() -> None:
     profile = UscoreBodyWeightProfile.create(
         status="final",
         subject=Reference(reference="Patient/example"),
@@ -107,7 +107,7 @@ def test_get_vscat_returns_flat_value():
     assert "coding" not in flat
 
 
-def test_get_vscat_raw_includes_discriminator():
+def test_get_vscat_raw_includes_discriminator() -> None:
     profile = UscoreBodyWeightProfile.create(
         status="final",
         subject=Reference(reference="Patient/example"),

--- a/examples/python-us-core/test_profile_bp.py
+++ b/examples/python-us-core/test_profile_bp.py
@@ -8,7 +8,7 @@ import warnings
 
 from fhir_types.hl7_fhir_r4_core.base import CodeableConcept, Coding, Quantity, Reference
 from fhir_types.hl7_fhir_r4_core.observation import Observation, ObservationComponent
-from fhir_types.hl7_fhir_r4_core.resource import Meta
+from fhir_types.hl7_fhir_r4_core.base import Meta
 from fhir_types.hl7_fhir_us_core.profiles.observation_uscore_blood_pressure_profile import UscoreBloodPressureProfile
 
 # Pydantic warns when extensions list contains plain dicts instead of Extension
@@ -32,7 +32,7 @@ def _make_bp() -> UscoreBloodPressureProfile:
 # ---------------------------------------------------------------------------
 
 
-def test_import_profiled_observation_from_api_and_read_components():
+def test_import_profiled_observation_from_api_and_read_components() -> None:
     api_response = Observation(
         resource_type="Observation",
         meta=Meta(profile=[CANONICAL_URL]),
@@ -70,7 +70,7 @@ def test_import_profiled_observation_from_api_and_read_components():
     assert profile.get_effective_date_time() == "2024-06-15"
 
 
-def test_apply_profile_to_bare_observation_and_populate_it():
+def test_apply_profile_to_bare_observation_and_populate_it() -> None:
     bare_observation = Observation(resource_type="Observation", status="preliminary", code=CodeableConcept())
     profile = UscoreBloodPressureProfile.apply(bare_observation)
 
@@ -91,11 +91,11 @@ def test_apply_profile_to_bare_observation_and_populate_it():
 # ---------------------------------------------------------------------------
 
 
-def test_canonical_url_is_exposed():
+def test_canonical_url_is_exposed() -> None:
     assert UscoreBloodPressureProfile.canonical_url == CANONICAL_URL
 
 
-def test_create_auto_sets_code_and_meta_profile():
+def test_create_auto_sets_code_and_meta_profile() -> None:
     profile = _make_bp()
     obs = profile.to_resource()
     assert obs.resource_type == "Observation"
@@ -104,7 +104,7 @@ def test_create_auto_sets_code_and_meta_profile():
     assert obs.meta.profile == [CANONICAL_URL]
 
 
-def test_freshly_created_profile_is_not_yet_valid_missing_effective():
+def test_freshly_created_profile_is_not_yet_valid_missing_effective() -> None:
     profile = _make_bp()
     errors = profile.validate()["errors"]
     assert errors == [
@@ -112,13 +112,13 @@ def test_freshly_created_profile_is_not_yet_valid_missing_effective():
     ]
 
 
-def test_create_auto_populates_component_with_systolic_diastolic_stubs():
+def test_create_auto_populates_component_with_systolic_diastolic_stubs() -> None:
     profile = _make_bp()
     obs = profile.to_resource()
     assert len(obs.component) == 2
 
 
-def test_set_systolic_get_systolic_get_systolic_raw():
+def test_set_systolic_get_systolic_get_systolic_raw() -> None:
     profile = _make_bp()
     profile.set_systolic({"value": 120, "unit": "mmHg", "system": "http://unitsofmeasure.org", "code": "mm[Hg]"})
 
@@ -134,7 +134,7 @@ def test_set_systolic_get_systolic_get_systolic_raw():
     assert raw.code.coding[0].code == "8480-6"
 
 
-def test_set_diastolic_get_diastolic_get_diastolic_raw():
+def test_set_diastolic_get_diastolic_get_diastolic_raw() -> None:
     profile = _make_bp()
     profile.set_diastolic({"value": 80, "unit": "mmHg", "system": "http://unitsofmeasure.org", "code": "mm[Hg]"})
 
@@ -150,13 +150,13 @@ def test_set_diastolic_get_diastolic_get_diastolic_raw():
     assert raw.code.coding[0].code == "8462-4"
 
 
-def test_both_systolic_and_diastolic_are_in_the_component_array():
+def test_both_systolic_and_diastolic_are_in_the_component_array() -> None:
     profile = _make_bp()
     obs = profile.to_resource()
     assert len(obs.component) == 2
 
 
-def test_set_systolic_replaces_an_existing_systolic_component():
+def test_set_systolic_replaces_an_existing_systolic_component() -> None:
     profile = _make_bp()
     profile.set_systolic({"value": 130, "unit": "mmHg"})
     obs = profile.to_resource()
@@ -164,21 +164,21 @@ def test_set_systolic_replaces_an_existing_systolic_component():
     assert profile.get_systolic("raw").value_quantity.value == 130
 
 
-def test_set_vscat_adds_category_with_discriminator_values():
+def test_set_vscat_adds_category_with_discriminator_values() -> None:
     profile = _make_bp()
     profile.set_vscat({"text": "Vital Signs"})
     flat = profile.get_vscat()
     assert flat["text"] == "Vital Signs"
 
 
-def test_set_effective_date_time_get_effective_date_time():
+def test_set_effective_date_time_get_effective_date_time() -> None:
     profile = _make_bp()
     profile.set_effective_date_time("2024-06-15T10:30:00Z")
     assert profile.get_effective_date_time() == "2024-06-15T10:30:00Z"
     assert profile.get_value_quantity() is None
 
 
-def test_fluent_chaining_across_all_accessor_types():
+def test_fluent_chaining_across_all_accessor_types() -> None:
     profile = _make_bp()
     result = (
         profile.set_status("final")
@@ -193,13 +193,13 @@ def test_fluent_chaining_across_all_accessor_types():
     assert profile.get_subject().reference == "Patient/pt-2"
 
 
-def test_set_systolic_with_no_args_inserts_discriminator_only_component():
+def test_set_systolic_with_no_args_inserts_discriminator_only_component() -> None:
     profile = _make_bp()
-    profile.set_systolic()  # type: ignore[call-arg]
+    profile.set_systolic()
     assert profile.get_systolic() is not None
 
 
-def test_create_with_custom_category_preserves_user_values_and_adds_required_vscat():
+def test_create_with_custom_category_preserves_user_values_and_adds_required_vscat() -> None:
     custom = UscoreBloodPressureProfile.create(
         status="final",
         subject=Reference(reference="Patient/pt-1"),
@@ -209,7 +209,7 @@ def test_create_with_custom_category_preserves_user_values_and_adds_required_vsc
     assert len(obs.category) == 2
 
 
-def test_create_with_empty_category_still_adds_required_vscat():
+def test_create_with_empty_category_still_adds_required_vscat() -> None:
     custom = UscoreBloodPressureProfile.create(
         status="final",
         subject=Reference(reference="Patient/pt-1"),
@@ -219,7 +219,7 @@ def test_create_with_empty_category_still_adds_required_vscat():
     assert len(obs.category) == 1
 
 
-def test_create_with_category_already_containing_vscat_does_not_duplicate_it():
+def test_create_with_category_already_containing_vscat_does_not_duplicate_it() -> None:
     custom = UscoreBloodPressureProfile.create(
         status="final",
         subject=Reference(reference="Patient/pt-1"),

--- a/examples/python-us-core/test_profile_patient.py
+++ b/examples/python-us-core/test_profile_patient.py
@@ -33,7 +33,7 @@ SEX_URL = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-individual-se
 # ---------------------------------------------------------------------------
 
 
-def test_set_extension_via_flat_input():
+def test_set_extension_via_flat_input() -> None:
     """Flat-dict form of the extension setters (the only form Python currently supports)."""
     patient = UscorePatientProfile.create(
         identifier=[Identifier(system="http://hospital.example.org/mrn", value="MRN-12345")],
@@ -65,7 +65,7 @@ def test_set_extension_via_flat_input():
     assert len(res.extension) == 3
 
 
-def test_set_extension_via_extension_profile_instance():
+def test_set_extension_via_extension_profile_instance() -> None:
     patient = UscorePatientProfile.create(
         identifier=[Identifier(system="http://hospital.example.org/mrn", value="MRN-12345")],
         name=[HumanName(family="Garcia", given=["Maria", "Elena"])],
@@ -77,7 +77,7 @@ def test_set_extension_via_extension_profile_instance():
     assert patient.get_ethnicity() is not None
 
 
-def test_set_extension_via_raw_extension():
+def test_set_extension_via_raw_extension() -> None:
     patient = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -87,7 +87,7 @@ def test_set_extension_via_raw_extension():
     assert patient.get_sex().code == "female"
 
 
-def test_import_profiled_resource_from_api_and_access_data_via_typed_getters():
+def test_import_profiled_resource_from_api_and_access_data_via_typed_getters() -> None:
     api_response = Patient(
         resource_type="Patient",
         meta={"profile": [CANONICAL_URL]},
@@ -127,7 +127,7 @@ def test_import_profiled_resource_from_api_and_access_data_via_typed_getters():
     assert patient.get_ethnicity() is None
 
 
-def test_apply_profile_to_a_bare_resource_and_populate_it():
+def test_apply_profile_to_a_bare_resource_and_populate_it() -> None:
     patient = UscorePatientProfile.apply(Patient(resource_type="Patient"))
 
     patient.set_identifier([Identifier(system="http://hospital.example.org/mrn", value="MRN-00001")])
@@ -153,7 +153,7 @@ def test_apply_profile_to_a_bare_resource_and_populate_it():
 # ---------------------------------------------------------------------------
 
 
-def test_create_returns_a_profile_wrapping_the_resource():
+def test_create_returns_a_profile_wrapping_the_resource() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(system="http://hospital.example.org", value="12345")],
         name=[HumanName(family="Smith", given=["John"])],
@@ -165,7 +165,7 @@ def test_create_returns_a_profile_wrapping_the_resource():
     assert res.name[0].family == "Smith"
 
 
-def test_create_resource_returns_a_plain_patient():
+def test_create_resource_returns_a_plain_patient() -> None:
     res = UscorePatientProfile.create_resource(
         identifier=[Identifier(system="http://hospital.example.org", value="12345")],
         name=[HumanName(family="Smith", given=["John"])],
@@ -175,7 +175,7 @@ def test_create_resource_returns_a_plain_patient():
     assert res.identifier[0].value == "12345"
 
 
-def test_apply_wraps_an_existing_patient():
+def test_apply_wraps_an_existing_patient() -> None:
     patient = Patient(resource_type="Patient")
     profile = UscorePatientProfile.apply(patient)
 
@@ -187,7 +187,7 @@ def test_apply_wraps_an_existing_patient():
     assert profile.get_name()[0].family == "Smith"
 
 
-def test_all_three_methods_produce_equivalent_resources():
+def test_all_three_methods_produce_equivalent_resources() -> None:
     identifier = [Identifier(system="http://hospital.example.org", value="12345")]
     name = [HumanName(family="Smith", given=["John"])]
     from_create = UscorePatientProfile.create(identifier=identifier, name=name).to_resource()
@@ -216,21 +216,21 @@ def _make_patient() -> UscorePatientProfile:
     )
 
 
-def test_get_identifier_set_identifier():
+def test_get_identifier_set_identifier() -> None:
     profile = _make_patient()
     assert profile.get_identifier()[0].value == "12345"
     profile.set_identifier([Identifier(system="http://hospital.example.org", value="67890")])
     assert profile.get_identifier()[0].value == "67890"
 
 
-def test_get_name_set_name():
+def test_get_name_set_name() -> None:
     profile = _make_patient()
     assert profile.get_name()[0].family == "Smith"
     profile.set_name([HumanName(family="Doe", given=["Jane"])])
     assert profile.get_name()[0].family == "Doe"
 
 
-def test_fluent_chaining_across_field_accessors():
+def test_fluent_chaining_across_field_accessors() -> None:
     profile = _make_patient()
     result = profile.set_identifier(
         [Identifier(system="http://hospital.example.org", value="AAA")]
@@ -246,11 +246,11 @@ def test_fluent_chaining_across_field_accessors():
 # ---------------------------------------------------------------------------
 
 
-def test_canonical_url_is_exposed():
+def test_canonical_url_is_exposed() -> None:
     assert UscorePatientProfile.canonical_url == CANONICAL_URL
 
 
-def test_set_race_get_race_round_trip_with_detailed_categories():
+def test_set_race_get_race_round_trip_with_detailed_categories() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -269,19 +269,19 @@ def test_set_race_get_race_round_trip_with_detailed_categories():
     assert race["text"] == "White European"
 
 
-def test_get_race_raw_returns_raw_extension():
+def test_get_race_raw_returns_raw_extension() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
     )
     profile.set_race({"ombCategory": {"code": "2106-3", "display": "White"}, "text": "White"})
 
-    raw = profile.get_race("raw")  # type: ignore[call-arg]
+    raw = profile.get_race("raw")
     assert raw is not None
     assert raw.url == RACE_URL
 
 
-def test_set_sex_get_sex_round_trip():
+def test_set_sex_get_sex_round_trip() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -292,19 +292,19 @@ def test_set_sex_get_sex_round_trip():
     assert sex.code == "male"
 
 
-def test_get_sex_raw_returns_raw_extension():
+def test_get_sex_raw_returns_raw_extension() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
     )
     profile.set_sex(Coding(system="http://hl7.org/fhir/administrative-gender", code="female"))
 
-    raw = profile.get_sex("raw")  # type: ignore[call-arg]
+    raw = profile.get_sex("raw")
     assert raw.url == SEX_URL
     assert raw.value_coding.code == "female"
 
 
-def test_extension_getters_return_none_when_not_set():
+def test_extension_getters_return_none_when_not_set() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -317,20 +317,20 @@ def test_extension_getters_return_none_when_not_set():
     assert profile.get_interpreter_required() is None
 
 
-def test_extension_raw_getters_return_none_when_not_set():
+def test_extension_raw_getters_return_none_when_not_set() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
     )
 
-    assert profile.get_race("raw") is None  # type: ignore[call-arg]
-    assert profile.get_ethnicity("raw") is None  # type: ignore[call-arg]
-    assert profile.get_sex("raw") is None  # type: ignore[call-arg]
-    assert profile.get_tribal_affiliation("raw") is None  # type: ignore[call-arg]
-    assert profile.get_interpreter_required("raw") is None  # type: ignore[call-arg]
+    assert profile.get_race("raw") is None
+    assert profile.get_ethnicity("raw") is None
+    assert profile.get_sex("raw") is None
+    assert profile.get_tribal_affiliation("raw") is None
+    assert profile.get_interpreter_required("raw") is None
 
 
-def test_fluent_chaining_across_extensions():
+def test_fluent_chaining_across_extensions() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -352,7 +352,7 @@ def test_fluent_chaining_across_extensions():
     assert profile.get_interpreter_required().code == "no"
 
 
-def test_extensions_are_added_to_the_resource():
+def test_extensions_are_added_to_the_resource() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -373,7 +373,7 @@ def test_extensions_are_added_to_the_resource():
 # ---------------------------------------------------------------------------
 
 
-def test_set_race_accepts_extension_profile_instance():
+def test_set_race_accepts_extension_profile_instance() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -384,7 +384,7 @@ def test_set_race_accepts_extension_profile_instance():
     assert profile.get_race() is not None
 
 
-def test_set_race_accepts_raw_extension():
+def test_set_race_accepts_raw_extension() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -400,7 +400,7 @@ def test_set_race_accepts_raw_extension():
     assert profile.get_race() is not None
 
 
-def test_set_race_throws_on_wrong_extension_url():
+def test_set_race_throws_on_wrong_extension_url() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -410,7 +410,7 @@ def test_set_race_throws_on_wrong_extension_url():
         profile.set_race(wrong_extension)
 
 
-def test_set_sex_accepts_extension_profile_instance():
+def test_set_sex_accepts_extension_profile_instance() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -420,7 +420,7 @@ def test_set_sex_accepts_extension_profile_instance():
     assert profile.get_sex().code == "male"
 
 
-def test_set_sex_accepts_raw_extension():
+def test_set_sex_accepts_raw_extension() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -435,7 +435,7 @@ def test_set_sex_accepts_raw_extension():
 # ---------------------------------------------------------------------------
 
 
-def test_profile_mutates_the_underlying_resource():
+def test_profile_mutates_the_underlying_resource() -> None:
     patient = Patient(resource_type="Patient")
     profile = UscorePatientProfile.apply(patient)
 
@@ -451,7 +451,7 @@ def test_profile_mutates_the_underlying_resource():
 # ---------------------------------------------------------------------------
 
 
-def test_freshly_created_profile_with_required_fields_is_valid():
+def test_freshly_created_profile_with_required_fields_is_valid() -> None:
     profile = UscorePatientProfile.create(
         identifier=[Identifier(value="1")],
         name=[HumanName(family="Test")],
@@ -459,7 +459,7 @@ def test_freshly_created_profile_with_required_fields_is_valid():
     assert profile.validate()["errors"] == []
 
 
-def test_profile_from_empty_resource_reports_missing_required_fields():
+def test_profile_from_empty_resource_reports_missing_required_fields() -> None:
     profile = UscorePatientProfile.apply(Patient(resource_type="Patient"))
     errors = profile.validate()["errors"]
 

--- a/examples/python-us-core/test_profile_typed_bundle.py
+++ b/examples/python-us-core/test_profile_typed_bundle.py
@@ -18,7 +18,7 @@ active_patient = Patient(resource_type="Patient", active=True)
 # ---------------------------------------------------------------------------
 
 
-def test_freshly_created_bundle_fails_validation_missing_patient_entry():
+def test_freshly_created_bundle_fails_validation_missing_patient_entry() -> None:
     bundle = ExampleTypedBundleProfile.create(type="collection")
     errors = bundle.validate()["errors"]
     assert errors == [
@@ -26,12 +26,12 @@ def test_freshly_created_bundle_fails_validation_missing_patient_entry():
     ]
 
 
-def test_set_patient_entry_accepts_typed_bundle_entry():
+def test_set_patient_entry_accepts_typed_bundle_entry() -> None:
     bundle = ExampleTypedBundleProfile.create(type="collection")
     bundle.set_patient_entry(BundleEntry(resource=smith_patient))
 
 
-def test_get_patient_entry_returns_bundle_entry_instance():
+def test_get_patient_entry_returns_bundle_entry_instance() -> None:
     bundle = ExampleTypedBundleProfile.create(type="collection")
     bundle.set_patient_entry(BundleEntry(resource=smith_patient))
 
@@ -41,7 +41,7 @@ def test_get_patient_entry_returns_bundle_entry_instance():
     assert entry.resource.name[0].family == "Smith"
 
 
-def test_get_patient_entry_raw_mode_returns_bundle_entry_instance():
+def test_get_patient_entry_raw_mode_returns_bundle_entry_instance() -> None:
     bundle = ExampleTypedBundleProfile.create(type="collection")
     bundle.set_patient_entry(BundleEntry(resource=smith_patient))
 
@@ -50,7 +50,7 @@ def test_get_patient_entry_raw_mode_returns_bundle_entry_instance():
     assert entry.resource.resource_type == "Patient"
 
 
-def test_get_patient_entry_returns_stored_entry_including_resource():
+def test_get_patient_entry_returns_stored_entry_including_resource() -> None:
     """Getter returns the stored entry as-is — resource data is preserved."""
     bundle = ExampleTypedBundleProfile.create(type="collection")
     bundle.set_patient_entry(BundleEntry(resource=smith_patient))
@@ -61,7 +61,7 @@ def test_get_patient_entry_returns_stored_entry_including_resource():
     assert resource is not None
 
 
-def test_set_patient_entry_replaces_existing():
+def test_set_patient_entry_replaces_existing() -> None:
     bundle = ExampleTypedBundleProfile.create(type="collection")
     bundle.set_patient_entry(BundleEntry(resource=smith_patient))
     bundle.set_patient_entry(BundleEntry(resource=active_patient))
@@ -75,7 +75,7 @@ def test_set_patient_entry_replaces_existing():
 # ---------------------------------------------------------------------------
 
 
-def test_set_organization_entry_accepts_a_list():
+def test_set_organization_entry_accepts_a_list() -> None:
     from fhir_types.hl7_fhir_r4_core.organization import Organization
 
     bundle = ExampleTypedBundleProfile.create(type="collection")
@@ -91,7 +91,7 @@ def test_set_organization_entry_accepts_a_list():
     assert len(orgs) == 2
 
 
-def test_get_organization_entry_returns_list():
+def test_get_organization_entry_returns_list() -> None:
     from fhir_types.hl7_fhir_r4_core.organization import Organization
 
     bundle = ExampleTypedBundleProfile.create(type="collection")

--- a/examples/python-us-core/us-core-demo/load.py
+++ b/examples/python-us-core/us-core-demo/load.py
@@ -56,8 +56,8 @@ def row_to_patient(row: Row) -> Patient:
         identifier=[Identifier(system="http://hospital.example.org/mrn", value=row.mrn)],
         name=[HumanName(family=row.last, given=[row.first])],
     )
-    resource.gender = row.gender  # type: ignore[assignment]
-    resource.birth_date = row.dob  # type: ignore[assignment]
+    resource.gender = row.gender
+    resource.birth_date = row.dob
 
     race = UscoreRaceExtension.create()
     race.set_extension_omb_category({

--- a/src/api/writer-generator/python/profile-extensions.ts
+++ b/src/api/writer-generator/python/profile-extensions.ts
@@ -222,7 +222,7 @@ const generateComplexExtensionGetter = (
     targetPath: string[],
     extProfileInfo: ExtensionProfileInfo | undefined,
 ): void => {
-    generateExtensionGetter(w, ext, baseName, "dict", targetPath, extProfileInfo, () => {
+    generateExtensionGetter(w, ext, baseName, "dict[str, Any]", targetPath, extProfileInfo, () => {
         const configItems = (ext.subExtensions ?? []).map((sub) => {
             const valueField = sub.valueFieldType
                 ? pyValueFieldName(sub.valueFieldType, w.nameFormatFunction)
@@ -268,7 +268,7 @@ const generateComplexExtensionSetter = (
     targetPath: string[],
     extProfileInfo: ExtensionProfileInfo | undefined,
 ): void => {
-    generateExtensionSetter(w, ext, className, baseName, "dict", targetPath, extProfileInfo, () => {
+    generateExtensionSetter(w, ext, className, baseName, "dict[str, Any]", targetPath, extProfileInfo, () => {
         w.line("sub_extensions = []");
         for (const sub of ext.subExtensions ?? []) {
             const valueField = sub.valueFieldType
@@ -311,7 +311,7 @@ const generateSingleValueExtensionGetter = (
     extProfileInfo: ExtensionProfileInfo | undefined,
 ): void => {
     generateExtensionGetter(w, ext, baseName, pyType, targetPath, extProfileInfo, () => {
-        w.line(`return get_extension_value(ext, ${JSON.stringify(valueField)})`);
+        w.line(`return cast('${pyType} | None', get_extension_value(ext, ${JSON.stringify(valueField)}))`);
     });
 };
 
@@ -341,8 +341,10 @@ const generateGenericExtensionGetter = (
     targetPath: string[],
     extProfileInfo: ExtensionProfileInfo | undefined,
 ): void => {
-    generateExtensionGetter(w, ext, baseName, "dict", targetPath, extProfileInfo, () => {
-        w.line("return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)");
+    generateExtensionGetter(w, ext, baseName, "dict[str, Any]", targetPath, extProfileInfo, () => {
+        w.line(
+            'return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))',
+        );
     });
 };
 
@@ -354,7 +356,7 @@ const generateGenericExtensionSetter = (
     targetPath: string[],
     extProfileInfo: ExtensionProfileInfo | undefined,
 ): void => {
-    generateExtensionSetter(w, ext, className, baseName, "dict", targetPath, extProfileInfo, () => {
+    generateExtensionSetter(w, ext, className, baseName, "dict[str, Any]", targetPath, extProfileInfo, () => {
         emitExtPush(w, targetPath, `{"url": ${JSON.stringify(ext.url)}, **value}`);
     });
 };

--- a/src/api/writer-generator/python/profile-factory.ts
+++ b/src/api/writer-generator/python/profile-factory.ts
@@ -282,7 +282,7 @@ export const generateFieldAccessors = (
         const methodSuffix = pySnakeName(p.name);
         w.line(`def get_${methodSuffix}(self) -> ${p.pyType} | None:`);
         w.indentBlock(() => {
-            w.line(`return getattr(self._resource, ${JSON.stringify(fieldName)}, None)`);
+            w.line(`return cast('${p.pyType} | None', getattr(self._resource, ${JSON.stringify(fieldName)}, None))`);
         });
         w.line();
         w.line(`def set_${methodSuffix}(self, value: ${p.pyType}) -> "${className}":`);
@@ -299,7 +299,7 @@ export const generateFieldAccessors = (
         const fieldName = pyFieldName(a.name, fmt);
         w.line(`def get_${methodSuffix}(self) -> ${a.pyType} | None:`);
         w.indentBlock(() => {
-            w.line(`return getattr(self._resource, ${JSON.stringify(fieldName)}, None)`);
+            w.line(`return cast('${a.pyType} | None', getattr(self._resource, ${JSON.stringify(fieldName)}, None))`);
         });
         w.line();
         w.line(`def set_${methodSuffix}(self, value: ${a.pyType}) -> "${className}":`);

--- a/src/api/writer-generator/python/profile-slices.ts
+++ b/src/api/writer-generator/python/profile-slices.ts
@@ -46,7 +46,7 @@ export const collectRequiredSliceNames = (field: RegularField): string[] | undef
 export const generateStaticSliceFields = (w: Python, sliceDefs: SliceDef[]): void => {
     for (const sliceDef of sliceDefs) {
         const staticName = pySliceStaticName(sliceDef.sliceName);
-        w.line(`${staticName}: dict = ${JSON.stringify(sliceDef.match)}`);
+        w.line(`${staticName}: dict[str, Any] = ${JSON.stringify(sliceDef.match)}`);
     }
     if (sliceDefs.length > 0) w.line();
 };
@@ -178,21 +178,21 @@ export const generateSliceGetters = (
                     w.line(
                         `result = get_array_slices(getattr(self._resource, ${JSON.stringify(fieldName)}, None), match)`,
                     );
-                    w.line("return result or None");
+                    w.line(`return cast('list[${retType}] | None', result or None)`);
                 });
             } else {
                 w.line(`def get_${baseName}(self, mode: str | None = None) -> ${retType} | None:`);
                 w.indentBlock(() => {
                     w.line(`match = self.__class__.${staticName}`);
                     w.line(
-                        `return get_array_slice(getattr(self._resource, ${JSON.stringify(fieldName)}, None), match)`,
+                        `return cast('${retType} | None', get_array_slice(getattr(self._resource, ${JSON.stringify(fieldName)}, None), match))`,
                     );
                 });
             }
         } else {
-            const flatRetType = sliceDef.constrainedChoice
-                ? pyTypeFromIdentifier(sliceDef.constrainedChoice.variantType)
-                : "dict";
+            // The flat form is always a plain dict at runtime (helpers return dict[str, Any]),
+            // including constrained-choice slices where the variant wrapper is unwrapped.
+            const flatRetType = "dict[str, Any]";
             const rawRetType = sliceDef.elementTypeName ?? "Any";
             w.line("@overload");
             w.line(`def get_${baseName}(self) -> ${flatRetType} | None: ...`);
@@ -216,7 +216,7 @@ export const generateSliceGetters = (
                 }
                 w.line('if mode == "raw":');
                 w.indentBlock(() => {
-                    w.line("return item");
+                    w.line(`return cast('${rawRetType} | None', item)`);
                 });
                 w.line(
                     "item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)",
@@ -271,8 +271,8 @@ export const generateSliceSetters = (
             // mirroring TS `inputOptional = sliceDef.required.length === 0`.
             const inputOptional = sliceDef.required.length === 0;
             const sig = inputOptional
-                ? `def set_${baseName}(self, value: dict | None = None) -> "${className}":`
-                : `def set_${baseName}(self, value: dict) -> "${className}":`;
+                ? `def set_${baseName}(self, value: dict[str, Any] | None = None) -> "${className}":`
+                : `def set_${baseName}(self, value: dict[str, Any]) -> "${className}":`;
             w.line(sig);
             w.indentBlock(() => {
                 w.line(`match = self.__class__.${staticName}`);

--- a/src/api/writer-generator/python/profile.ts
+++ b/src/api/writer-generator/python/profile.ts
@@ -157,9 +157,6 @@ const collectTypeImports = (
     for (const a of factoryInfo.accessors)
         addTypeImport(typeImports, rootPackageName, baseTypeName, resolveRef, a.typeId);
     for (const s of sliceDefs) {
-        // Constrained-choice slice getters return the variant type (e.g. `valueCoding` -> `Coding`).
-        if (s.constrainedChoice)
-            addExactTypeImport(typeImports, rootPackageName, baseTypeName, s.constrainedChoice.variantType);
         // The element type is referenced by both the setter (`ElementType(**merged)`) and the
         // raw getter overload, for type-discriminated and plain slices alike.
         if (s.elementTypeId) addExactTypeImport(typeImports, rootPackageName, baseTypeName, s.elementTypeId);
@@ -217,11 +214,18 @@ const emitModuleImports = (
     // Non-type-discriminated slice getters emit `@overload`s with a `Literal["raw"]` mode.
     const hasNonTypedSlice = sliceDefs.some((s) => !s.isTypeDiscriminated);
     const needsOverload = extensions.length > 0 || hasNonTypedSlice;
-    // `Any` is needed for extension setter inputs (`X | Extension | Any`) and for raw
-    // slice getters whose element type is unknown (`rawRetType = "Any"`).
-    const needsAny = extensions.length > 0 || sliceDefs.some((s) => !s.isTypeDiscriminated && !s.elementTypeName);
+    // `Any` is needed for extension setter inputs (`X | Extension | Any`) and for the
+    // `dict[str, Any]` slice match fields / flat getters / setters.
+    const needsAny = extensions.length > 0 || sliceDefs.length > 0;
+    // `cast` wraps `getattr`/helper results (which return `Any`) in accessor and slice getters.
+    const needsCast =
+        factoryInfo.params.length > 0 ||
+        factoryInfo.accessors.length > 0 ||
+        sliceDefs.length > 0 ||
+        extensions.length > 0;
     const typingNames: string[] = [];
     if (needsAny) typingNames.push("Any");
+    if (needsCast) typingNames.push("cast");
     if (needsOverload || usesLiteral) typingNames.push("Literal");
     if (needsOverload) typingNames.push("overload");
     if (typingNames.length > 0) {
@@ -479,6 +483,11 @@ const generateProfilesInit = (w: Python, tsIndex: TypeSchemaIndex, profiles: Sna
             seen.add(className);
             w.pyImportFrom(`.${moduleName}`, className);
         }
+        // Explicit re-export so strict mypy (no_implicit_reexport) sees these names.
+        w.line();
+        w.squareBlock(["__all__", "="], () => {
+            for (const className of [...seen].sort()) w.line(`'${className}',`);
+        });
     });
 };
 

--- a/test/api/write-generator/__snapshots__/python.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/python.test.ts.snap
@@ -417,7 +417,7 @@ exports[`Python R4 Example (with generateProfile) generates bodyweight profile w
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.observation import Observation
 from fhir_types.hl7_fhir_r4_core.base import CodeableConcept, Period, Quantity, Reference
@@ -436,7 +436,7 @@ class ObservationBodyweightProfile:
 
     canonical_url: str = "http://hl7.org/fhir/StructureDefinition/bodyweight"
 
-    _vscat_slice_match: dict = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
+    _vscat_slice_match: dict[str, Any] = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
 
     def __init__(self, resource: Observation) -> None:
         self._resource = resource
@@ -480,35 +480,35 @@ class ObservationBodyweightProfile:
         return self._resource
 
     def get_status(self) -> Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None:
-        return getattr(self._resource, "status", None)
+        return cast('Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None', getattr(self._resource, "status", None))
 
     def set_status(self, value: Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]) -> "ObservationBodyweightProfile":
         setattr(self._resource, "status", value)
         return self
 
     def get_subject(self) -> Reference | None:
-        return getattr(self._resource, "subject", None)
+        return cast('Reference | None', getattr(self._resource, "subject", None))
 
     def set_subject(self, value: Reference) -> "ObservationBodyweightProfile":
         setattr(self._resource, "subject", value)
         return self
 
     def get_category(self) -> list[CodeableConcept] | None:
-        return getattr(self._resource, "category", None)
+        return cast('list[CodeableConcept] | None', getattr(self._resource, "category", None))
 
     def set_category(self, value: list[CodeableConcept]) -> "ObservationBodyweightProfile":
         setattr(self._resource, "category", value)
         return self
 
     def get_code(self) -> CodeableConcept | None:
-        return getattr(self._resource, "code", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "code", None))
 
     def set_code(self, value: CodeableConcept) -> "ObservationBodyweightProfile":
         setattr(self._resource, "code", value)
         return self
 
     def get_effective_date_time(self) -> str | None:
-        return getattr(self._resource, "effective_date_time", None)
+        return cast('str | None', getattr(self._resource, "effective_date_time", None))
 
     def set_effective_date_time(self, value: str) -> "ObservationBodyweightProfile":
         setattr(self._resource, "effective_period", None)
@@ -516,7 +516,7 @@ class ObservationBodyweightProfile:
         return self
 
     def get_effective_period(self) -> Period | None:
-        return getattr(self._resource, "effective_period", None)
+        return cast('Period | None', getattr(self._resource, "effective_period", None))
 
     def set_effective_period(self, value: Period) -> "ObservationBodyweightProfile":
         setattr(self._resource, "effective_date_time", None)
@@ -524,25 +524,25 @@ class ObservationBodyweightProfile:
         return self
 
     def get_value_quantity(self) -> Quantity | None:
-        return getattr(self._resource, "value_quantity", None)
+        return cast('Quantity | None', getattr(self._resource, "value_quantity", None))
 
     def set_value_quantity(self, value: Quantity) -> "ObservationBodyweightProfile":
         setattr(self._resource, "value_quantity", value)
         return self
 
     @overload
-    def get_vscat(self) -> dict | None: ...
+    def get_vscat(self) -> dict[str, Any] | None: ...
     @overload
     def get_vscat(self, mode: Literal["raw"]) -> CodeableConcept | None: ...
-    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict | CodeableConcept | None:
+    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | CodeableConcept | None:
         match = self.__class__._vscat_slice_match
         item = get_array_slice(getattr(self._resource, "category", None), match)
         if mode == "raw":
-            return item
+            return cast('CodeableConcept | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["coding"])
 
-    def set_vscat(self, value: dict | None = None) -> "ObservationBodyweightProfile":
+    def set_vscat(self, value: dict[str, Any] | None = None) -> "ObservationBodyweightProfile":
         match = self.__class__._vscat_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = CodeableConcept(**merged)
@@ -582,7 +582,7 @@ exports[`Python R4 Example (with generateProfile) generates bp profile with vali
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.observation import Observation
 from fhir_types.hl7_fhir_r4_core.base import (
@@ -604,9 +604,9 @@ class ObservationBpProfile:
 
     canonical_url: str = "http://hl7.org/fhir/StructureDefinition/bp"
 
-    _vscat_slice_match: dict = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
-    _systolic_bp_slice_match: dict = {"code":{"coding":[{"code":"8480-6","system":"http://loinc.org"}]}}
-    _diastolic_bp_slice_match: dict = {"code":{"coding":[{"code":"8462-4","system":"http://loinc.org"}]}}
+    _vscat_slice_match: dict[str, Any] = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
+    _systolic_bp_slice_match: dict[str, Any] = {"code":{"coding":[{"code":"8480-6","system":"http://loinc.org"}]}}
+    _diastolic_bp_slice_match: dict[str, Any] = {"code":{"coding":[{"code":"8462-4","system":"http://loinc.org"}]}}
 
     def __init__(self, resource: Observation) -> None:
         self._resource = resource
@@ -656,42 +656,42 @@ class ObservationBpProfile:
         return self._resource
 
     def get_status(self) -> Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None:
-        return getattr(self._resource, "status", None)
+        return cast('Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None', getattr(self._resource, "status", None))
 
     def set_status(self, value: Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]) -> "ObservationBpProfile":
         setattr(self._resource, "status", value)
         return self
 
     def get_subject(self) -> Reference | None:
-        return getattr(self._resource, "subject", None)
+        return cast('Reference | None', getattr(self._resource, "subject", None))
 
     def set_subject(self, value: Reference) -> "ObservationBpProfile":
         setattr(self._resource, "subject", value)
         return self
 
     def get_category(self) -> list[CodeableConcept] | None:
-        return getattr(self._resource, "category", None)
+        return cast('list[CodeableConcept] | None', getattr(self._resource, "category", None))
 
     def set_category(self, value: list[CodeableConcept]) -> "ObservationBpProfile":
         setattr(self._resource, "category", value)
         return self
 
     def get_code(self) -> CodeableConcept | None:
-        return getattr(self._resource, "code", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "code", None))
 
     def set_code(self, value: CodeableConcept) -> "ObservationBpProfile":
         setattr(self._resource, "code", value)
         return self
 
     def get_component(self) -> list[BackboneElement] | None:
-        return getattr(self._resource, "component", None)
+        return cast('list[BackboneElement] | None', getattr(self._resource, "component", None))
 
     def set_component(self, value: list[BackboneElement]) -> "ObservationBpProfile":
         setattr(self._resource, "component", value)
         return self
 
     def get_effective_date_time(self) -> str | None:
-        return getattr(self._resource, "effective_date_time", None)
+        return cast('str | None', getattr(self._resource, "effective_date_time", None))
 
     def set_effective_date_time(self, value: str) -> "ObservationBpProfile":
         setattr(self._resource, "effective_period", None)
@@ -699,7 +699,7 @@ class ObservationBpProfile:
         return self
 
     def get_effective_period(self) -> Period | None:
-        return getattr(self._resource, "effective_period", None)
+        return cast('Period | None', getattr(self._resource, "effective_period", None))
 
     def set_effective_period(self, value: Period) -> "ObservationBpProfile":
         setattr(self._resource, "effective_date_time", None)
@@ -707,49 +707,49 @@ class ObservationBpProfile:
         return self
 
     def get_value_quantity(self) -> Quantity | None:
-        return getattr(self._resource, "value_quantity", None)
+        return cast('Quantity | None', getattr(self._resource, "value_quantity", None))
 
     def set_value_quantity(self, value: Quantity) -> "ObservationBpProfile":
         setattr(self._resource, "value_quantity", value)
         return self
 
     @overload
-    def get_vscat(self) -> dict | None: ...
+    def get_vscat(self) -> dict[str, Any] | None: ...
     @overload
     def get_vscat(self, mode: Literal["raw"]) -> CodeableConcept | None: ...
-    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict | CodeableConcept | None:
+    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | CodeableConcept | None:
         match = self.__class__._vscat_slice_match
         item = get_array_slice(getattr(self._resource, "category", None), match)
         if mode == "raw":
-            return item
+            return cast('CodeableConcept | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["coding"])
 
     @overload
-    def get_systolic_bp(self) -> Quantity | None: ...
+    def get_systolic_bp(self) -> dict[str, Any] | None: ...
     @overload
     def get_systolic_bp(self, mode: Literal["raw"]) -> ObservationComponent | None: ...
-    def get_systolic_bp(self, mode: Literal["raw"] | None = None) -> Quantity | ObservationComponent | None:
+    def get_systolic_bp(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | ObservationComponent | None:
         match = self.__class__._systolic_bp_slice_match
         item = get_array_slice(getattr(self._resource, "component", None), match)
         if mode == "raw":
-            return item
+            return cast('ObservationComponent | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["code"], "valueQuantity")
 
     @overload
-    def get_diastolic_bp(self) -> Quantity | None: ...
+    def get_diastolic_bp(self) -> dict[str, Any] | None: ...
     @overload
     def get_diastolic_bp(self, mode: Literal["raw"]) -> ObservationComponent | None: ...
-    def get_diastolic_bp(self, mode: Literal["raw"] | None = None) -> Quantity | ObservationComponent | None:
+    def get_diastolic_bp(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | ObservationComponent | None:
         match = self.__class__._diastolic_bp_slice_match
         item = get_array_slice(getattr(self._resource, "component", None), match)
         if mode == "raw":
-            return item
+            return cast('ObservationComponent | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["code"], "valueQuantity")
 
-    def set_vscat(self, value: dict | None = None) -> "ObservationBpProfile":
+    def set_vscat(self, value: dict[str, Any] | None = None) -> "ObservationBpProfile":
         match = self.__class__._vscat_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = CodeableConcept(**merged)
@@ -758,7 +758,7 @@ class ObservationBpProfile:
         setattr(self._resource, "category", items)
         return self
 
-    def set_systolic_bp(self, value: dict | None = None) -> "ObservationBpProfile":
+    def set_systolic_bp(self, value: dict[str, Any] | None = None) -> "ObservationBpProfile":
         match = self.__class__._systolic_bp_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueQuantity")
         merged = apply_slice_match(wrapped, match)
@@ -768,7 +768,7 @@ class ObservationBpProfile:
         setattr(self._resource, "component", items)
         return self
 
-    def set_diastolic_bp(self, value: dict | None = None) -> "ObservationBpProfile":
+    def set_diastolic_bp(self, value: dict[str, Any] | None = None) -> "ObservationBpProfile":
         match = self.__class__._diastolic_bp_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueQuantity")
         merged = apply_slice_match(wrapped, match)
@@ -811,7 +811,7 @@ exports[`Python US Core Example generates US Core Patient profile 1`] = `
 
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.patient import Patient
 from fhir_types.hl7_fhir_r4_core.base import Extension
@@ -873,26 +873,26 @@ class UscorePatientProfile:
         return self._resource
 
     def get_identifier(self) -> list[Identifier] | None:
-        return getattr(self._resource, "identifier", None)
+        return cast('list[Identifier] | None', getattr(self._resource, "identifier", None))
 
     def set_identifier(self, value: list[Identifier]) -> "UscorePatientProfile":
         setattr(self._resource, "identifier", value)
         return self
 
     def get_name(self) -> list[HumanName] | None:
-        return getattr(self._resource, "name", None)
+        return cast('list[HumanName] | None', getattr(self._resource, "name", None))
 
     def set_name(self, value: list[HumanName]) -> "UscorePatientProfile":
         setattr(self._resource, "name", value)
         return self
 
     @overload
-    def get_race(self) -> dict | None: ...
+    def get_race(self) -> dict[str, Any] | None: ...
     @overload
     def get_race(self, mode: Literal["raw"]) -> Extension | None: ...
     @overload
     def get_race(self, mode: Literal["profile"]) -> UscoreRaceExtension | None: ...
-    def get_race(self, mode: Literal["raw", "profile"] | None = None) -> dict | Extension | UscoreRaceExtension | None:
+    def get_race(self, mode: Literal["raw", "profile"] | None = None) -> dict[str, Any] | Extension | UscoreRaceExtension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race")), None)
         if ext is None:
@@ -905,7 +905,7 @@ class UscorePatientProfile:
         config = [{"name": "ombCategory", "valueField": "value_coding", "isArray": False}, {"name": "detailed", "valueField": "value_coding", "isArray": True}, {"name": "text", "valueField": "value_string", "isArray": False}]
         return extract_complex_extension(ext, config)
 
-    def set_race(self, value: "UscoreRaceExtension | Extension | dict") -> "UscorePatientProfile":
+    def set_race(self, value: "UscoreRaceExtension | Extension | dict[str, Any]") -> "UscorePatientProfile":
         if isinstance(value, UscoreRaceExtension):
             push_extension(self._resource, value.to_resource())
         elif is_extension(value):
@@ -924,12 +924,12 @@ class UscorePatientProfile:
         return self
 
     @overload
-    def get_ethnicity(self) -> dict | None: ...
+    def get_ethnicity(self) -> dict[str, Any] | None: ...
     @overload
     def get_ethnicity(self, mode: Literal["raw"]) -> Extension | None: ...
     @overload
     def get_ethnicity(self, mode: Literal["profile"]) -> UscoreEthnicityExtension | None: ...
-    def get_ethnicity(self, mode: Literal["raw", "profile"] | None = None) -> dict | Extension | UscoreEthnicityExtension | None:
+    def get_ethnicity(self, mode: Literal["raw", "profile"] | None = None) -> dict[str, Any] | Extension | UscoreEthnicityExtension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity")), None)
         if ext is None:
@@ -942,7 +942,7 @@ class UscorePatientProfile:
         config = [{"name": "ombCategory", "valueField": "value_coding", "isArray": False}, {"name": "detailed", "valueField": "value_coding", "isArray": True}, {"name": "text", "valueField": "value_string", "isArray": False}]
         return extract_complex_extension(ext, config)
 
-    def set_ethnicity(self, value: "UscoreEthnicityExtension | Extension | dict") -> "UscorePatientProfile":
+    def set_ethnicity(self, value: "UscoreEthnicityExtension | Extension | dict[str, Any]") -> "UscorePatientProfile":
         if isinstance(value, UscoreEthnicityExtension):
             push_extension(self._resource, value.to_resource())
         elif is_extension(value):
@@ -961,12 +961,12 @@ class UscorePatientProfile:
         return self
 
     @overload
-    def get_tribal_affiliation(self) -> dict | None: ...
+    def get_tribal_affiliation(self) -> dict[str, Any] | None: ...
     @overload
     def get_tribal_affiliation(self, mode: Literal["raw"]) -> Extension | None: ...
     @overload
     def get_tribal_affiliation(self, mode: Literal["profile"]) -> UscoreTribalAffiliationExtension | None: ...
-    def get_tribal_affiliation(self, mode: Literal["raw", "profile"] | None = None) -> dict | Extension | UscoreTribalAffiliationExtension | None:
+    def get_tribal_affiliation(self, mode: Literal["raw", "profile"] | None = None) -> dict[str, Any] | Extension | UscoreTribalAffiliationExtension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation")), None)
         if ext is None:
@@ -979,7 +979,7 @@ class UscorePatientProfile:
         config = [{"name": "tribalAffiliation", "valueField": "value_codeable_concept", "isArray": False}, {"name": "isEnrolled", "valueField": "value_boolean", "isArray": False}]
         return extract_complex_extension(ext, config)
 
-    def set_tribal_affiliation(self, value: "UscoreTribalAffiliationExtension | Extension | dict") -> "UscorePatientProfile":
+    def set_tribal_affiliation(self, value: "UscoreTribalAffiliationExtension | Extension | dict[str, Any]") -> "UscorePatientProfile":
         if isinstance(value, UscoreTribalAffiliationExtension):
             push_extension(self._resource, value.to_resource())
         elif is_extension(value):
@@ -1011,7 +1011,7 @@ class UscorePatientProfile:
             return ext_obj
         if mode == "profile":
             return UscoreIndividualSexExtension.apply(ext_obj)
-        return get_extension_value(ext, "value_coding")
+        return cast('Coding | None', get_extension_value(ext, "value_coding"))
 
     def set_sex(self, value: "UscoreIndividualSexExtension | Extension | Any") -> "UscorePatientProfile":
         if isinstance(value, UscoreIndividualSexExtension):
@@ -1040,7 +1040,7 @@ class UscorePatientProfile:
             return ext_obj
         if mode == "profile":
             return UscoreInterpreterNeededExtension.apply(ext_obj)
-        return get_extension_value(ext, "value_coding")
+        return cast('Coding | None', get_extension_value(ext, "value_coding"))
 
     def set_interpreter_required(self, value: "UscoreInterpreterNeededExtension | Extension | Any") -> "UscorePatientProfile":
         if isinstance(value, UscoreInterpreterNeededExtension):
@@ -1073,7 +1073,7 @@ exports[`Python US Core Example generates US Core Blood Pressure profile 1`] = `
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.observation import Observation
 from fhir_types.hl7_fhir_r4_core.base import (
@@ -1095,9 +1095,9 @@ class UscoreBloodPressureProfile:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
 
-    _vscat_slice_match: dict = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
-    _systolic_slice_match: dict = {"code":{"coding":[{"system":"http://loinc.org","code":"8480-6"}]}}
-    _diastolic_slice_match: dict = {"code":{"coding":[{"system":"http://loinc.org","code":"8462-4"}]}}
+    _vscat_slice_match: dict[str, Any] = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
+    _systolic_slice_match: dict[str, Any] = {"code":{"coding":[{"system":"http://loinc.org","code":"8480-6"}]}}
+    _diastolic_slice_match: dict[str, Any] = {"code":{"coding":[{"system":"http://loinc.org","code":"8462-4"}]}}
 
     def __init__(self, resource: Observation) -> None:
         self._resource = resource
@@ -1147,42 +1147,42 @@ class UscoreBloodPressureProfile:
         return self._resource
 
     def get_status(self) -> Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None:
-        return getattr(self._resource, "status", None)
+        return cast('Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None', getattr(self._resource, "status", None))
 
     def set_status(self, value: Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "status", value)
         return self
 
     def get_subject(self) -> Reference | None:
-        return getattr(self._resource, "subject", None)
+        return cast('Reference | None', getattr(self._resource, "subject", None))
 
     def set_subject(self, value: Reference) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "subject", value)
         return self
 
     def get_category(self) -> list[CodeableConcept] | None:
-        return getattr(self._resource, "category", None)
+        return cast('list[CodeableConcept] | None', getattr(self._resource, "category", None))
 
     def set_category(self, value: list[CodeableConcept]) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "category", value)
         return self
 
     def get_code(self) -> CodeableConcept | None:
-        return getattr(self._resource, "code", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "code", None))
 
     def set_code(self, value: CodeableConcept) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "code", value)
         return self
 
     def get_component(self) -> list[BackboneElement] | None:
-        return getattr(self._resource, "component", None)
+        return cast('list[BackboneElement] | None', getattr(self._resource, "component", None))
 
     def set_component(self, value: list[BackboneElement]) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "component", value)
         return self
 
     def get_effective_date_time(self) -> str | None:
-        return getattr(self._resource, "effective_date_time", None)
+        return cast('str | None', getattr(self._resource, "effective_date_time", None))
 
     def set_effective_date_time(self, value: str) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "effective_period", None)
@@ -1190,7 +1190,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_effective_period(self) -> Period | None:
-        return getattr(self._resource, "effective_period", None)
+        return cast('Period | None', getattr(self._resource, "effective_period", None))
 
     def set_effective_period(self, value: Period) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "effective_date_time", None)
@@ -1198,7 +1198,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_quantity(self) -> Quantity | None:
-        return getattr(self._resource, "value_quantity", None)
+        return cast('Quantity | None', getattr(self._resource, "value_quantity", None))
 
     def set_value_quantity(self, value: Quantity) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_codeable_concept", None)
@@ -1215,7 +1215,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_codeable_concept(self) -> CodeableConcept | None:
-        return getattr(self._resource, "value_codeable_concept", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "value_codeable_concept", None))
 
     def set_value_codeable_concept(self, value: CodeableConcept) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1232,7 +1232,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_string(self) -> str | None:
-        return getattr(self._resource, "value_string", None)
+        return cast('str | None', getattr(self._resource, "value_string", None))
 
     def set_value_string(self, value: str) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1249,7 +1249,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_boolean(self) -> bool | None:
-        return getattr(self._resource, "value_boolean", None)
+        return cast('bool | None', getattr(self._resource, "value_boolean", None))
 
     def set_value_boolean(self, value: bool) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1266,7 +1266,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_integer(self) -> int | None:
-        return getattr(self._resource, "value_integer", None)
+        return cast('int | None', getattr(self._resource, "value_integer", None))
 
     def set_value_integer(self, value: int) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1283,7 +1283,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_range(self) -> Range | None:
-        return getattr(self._resource, "value_range", None)
+        return cast('Range | None', getattr(self._resource, "value_range", None))
 
     def set_value_range(self, value: Range) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1300,7 +1300,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_ratio(self) -> Ratio | None:
-        return getattr(self._resource, "value_ratio", None)
+        return cast('Ratio | None', getattr(self._resource, "value_ratio", None))
 
     def set_value_ratio(self, value: Ratio) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1317,7 +1317,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_sampled_data(self) -> SampledData | None:
-        return getattr(self._resource, "value_sampled_data", None)
+        return cast('SampledData | None', getattr(self._resource, "value_sampled_data", None))
 
     def set_value_sampled_data(self, value: SampledData) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1334,7 +1334,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_time(self) -> str | None:
-        return getattr(self._resource, "value_time", None)
+        return cast('str | None', getattr(self._resource, "value_time", None))
 
     def set_value_time(self, value: str) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1351,7 +1351,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_date_time(self) -> str | None:
-        return getattr(self._resource, "value_date_time", None)
+        return cast('str | None', getattr(self._resource, "value_date_time", None))
 
     def set_value_date_time(self, value: str) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1368,7 +1368,7 @@ class UscoreBloodPressureProfile:
         return self
 
     def get_value_period(self) -> Period | None:
-        return getattr(self._resource, "value_period", None)
+        return cast('Period | None', getattr(self._resource, "value_period", None))
 
     def set_value_period(self, value: Period) -> "UscoreBloodPressureProfile":
         setattr(self._resource, "value_quantity", None)
@@ -1385,42 +1385,42 @@ class UscoreBloodPressureProfile:
         return self
 
     @overload
-    def get_vscat(self) -> dict | None: ...
+    def get_vscat(self) -> dict[str, Any] | None: ...
     @overload
     def get_vscat(self, mode: Literal["raw"]) -> CodeableConcept | None: ...
-    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict | CodeableConcept | None:
+    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | CodeableConcept | None:
         match = self.__class__._vscat_slice_match
         item = get_array_slice(getattr(self._resource, "category", None), match)
         if mode == "raw":
-            return item
+            return cast('CodeableConcept | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["coding"])
 
     @overload
-    def get_systolic(self) -> Quantity | None: ...
+    def get_systolic(self) -> dict[str, Any] | None: ...
     @overload
     def get_systolic(self, mode: Literal["raw"]) -> ObservationComponent | None: ...
-    def get_systolic(self, mode: Literal["raw"] | None = None) -> Quantity | ObservationComponent | None:
+    def get_systolic(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | ObservationComponent | None:
         match = self.__class__._systolic_slice_match
         item = get_array_slice(getattr(self._resource, "component", None), match)
         if mode == "raw":
-            return item
+            return cast('ObservationComponent | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["code"], "valueQuantity")
 
     @overload
-    def get_diastolic(self) -> Quantity | None: ...
+    def get_diastolic(self) -> dict[str, Any] | None: ...
     @overload
     def get_diastolic(self, mode: Literal["raw"]) -> ObservationComponent | None: ...
-    def get_diastolic(self, mode: Literal["raw"] | None = None) -> Quantity | ObservationComponent | None:
+    def get_diastolic(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | ObservationComponent | None:
         match = self.__class__._diastolic_slice_match
         item = get_array_slice(getattr(self._resource, "component", None), match)
         if mode == "raw":
-            return item
+            return cast('ObservationComponent | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["code"], "valueQuantity")
 
-    def set_vscat(self, value: dict | None = None) -> "UscoreBloodPressureProfile":
+    def set_vscat(self, value: dict[str, Any] | None = None) -> "UscoreBloodPressureProfile":
         match = self.__class__._vscat_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = CodeableConcept(**merged)
@@ -1429,7 +1429,7 @@ class UscoreBloodPressureProfile:
         setattr(self._resource, "category", items)
         return self
 
-    def set_systolic(self, value: dict | None = None) -> "UscoreBloodPressureProfile":
+    def set_systolic(self, value: dict[str, Any] | None = None) -> "UscoreBloodPressureProfile":
         match = self.__class__._systolic_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueQuantity")
         merged = apply_slice_match(wrapped, match)
@@ -1439,7 +1439,7 @@ class UscoreBloodPressureProfile:
         setattr(self._resource, "component", items)
         return self
 
-    def set_diastolic(self, value: dict | None = None) -> "UscoreBloodPressureProfile":
+    def set_diastolic(self, value: dict[str, Any] | None = None) -> "UscoreBloodPressureProfile":
         match = self.__class__._diastolic_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueQuantity")
         merged = apply_slice_match(wrapped, match)
@@ -1484,7 +1484,7 @@ exports[`Python US Core Example generates US Core Body Weight profile 1`] = `
 
 from __future__ import annotations
 
-from typing import Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.observation import Observation
 from fhir_types.hl7_fhir_r4_core.base import (
@@ -1505,7 +1505,7 @@ class UscoreBodyWeightProfile:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight"
 
-    _vscat_slice_match: dict = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
+    _vscat_slice_match: dict[str, Any] = {"coding":[{"code":"vital-signs","system":"http://terminology.hl7.org/CodeSystem/observation-category"}]}
 
     def __init__(self, resource: Observation) -> None:
         self._resource = resource
@@ -1549,35 +1549,35 @@ class UscoreBodyWeightProfile:
         return self._resource
 
     def get_status(self) -> Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None:
-        return getattr(self._resource, "status", None)
+        return cast('Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"] | None', getattr(self._resource, "status", None))
 
     def set_status(self, value: Literal["registered", "preliminary", "final", "amended", "corrected", "cancelled", "entered-in-error", "unknown"]) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "status", value)
         return self
 
     def get_subject(self) -> Reference | None:
-        return getattr(self._resource, "subject", None)
+        return cast('Reference | None', getattr(self._resource, "subject", None))
 
     def set_subject(self, value: Reference) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "subject", value)
         return self
 
     def get_category(self) -> list[CodeableConcept] | None:
-        return getattr(self._resource, "category", None)
+        return cast('list[CodeableConcept] | None', getattr(self._resource, "category", None))
 
     def set_category(self, value: list[CodeableConcept]) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "category", value)
         return self
 
     def get_code(self) -> CodeableConcept | None:
-        return getattr(self._resource, "code", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "code", None))
 
     def set_code(self, value: CodeableConcept) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "code", value)
         return self
 
     def get_effective_date_time(self) -> str | None:
-        return getattr(self._resource, "effective_date_time", None)
+        return cast('str | None', getattr(self._resource, "effective_date_time", None))
 
     def set_effective_date_time(self, value: str) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "effective_period", None)
@@ -1585,7 +1585,7 @@ class UscoreBodyWeightProfile:
         return self
 
     def get_effective_period(self) -> Period | None:
-        return getattr(self._resource, "effective_period", None)
+        return cast('Period | None', getattr(self._resource, "effective_period", None))
 
     def set_effective_period(self, value: Period) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "effective_date_time", None)
@@ -1593,95 +1593,95 @@ class UscoreBodyWeightProfile:
         return self
 
     def get_value_quantity(self) -> Quantity | None:
-        return getattr(self._resource, "value_quantity", None)
+        return cast('Quantity | None', getattr(self._resource, "value_quantity", None))
 
     def set_value_quantity(self, value: Quantity) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_quantity", value)
         return self
 
     def get_value_codeable_concept(self) -> CodeableConcept | None:
-        return getattr(self._resource, "value_codeable_concept", None)
+        return cast('CodeableConcept | None', getattr(self._resource, "value_codeable_concept", None))
 
     def set_value_codeable_concept(self, value: CodeableConcept) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_codeable_concept", value)
         return self
 
     def get_value_string(self) -> str | None:
-        return getattr(self._resource, "value_string", None)
+        return cast('str | None', getattr(self._resource, "value_string", None))
 
     def set_value_string(self, value: str) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_string", value)
         return self
 
     def get_value_boolean(self) -> bool | None:
-        return getattr(self._resource, "value_boolean", None)
+        return cast('bool | None', getattr(self._resource, "value_boolean", None))
 
     def set_value_boolean(self, value: bool) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_boolean", value)
         return self
 
     def get_value_integer(self) -> int | None:
-        return getattr(self._resource, "value_integer", None)
+        return cast('int | None', getattr(self._resource, "value_integer", None))
 
     def set_value_integer(self, value: int) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_integer", value)
         return self
 
     def get_value_range(self) -> Range | None:
-        return getattr(self._resource, "value_range", None)
+        return cast('Range | None', getattr(self._resource, "value_range", None))
 
     def set_value_range(self, value: Range) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_range", value)
         return self
 
     def get_value_ratio(self) -> Ratio | None:
-        return getattr(self._resource, "value_ratio", None)
+        return cast('Ratio | None', getattr(self._resource, "value_ratio", None))
 
     def set_value_ratio(self, value: Ratio) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_ratio", value)
         return self
 
     def get_value_sampled_data(self) -> SampledData | None:
-        return getattr(self._resource, "value_sampled_data", None)
+        return cast('SampledData | None', getattr(self._resource, "value_sampled_data", None))
 
     def set_value_sampled_data(self, value: SampledData) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_sampled_data", value)
         return self
 
     def get_value_time(self) -> str | None:
-        return getattr(self._resource, "value_time", None)
+        return cast('str | None', getattr(self._resource, "value_time", None))
 
     def set_value_time(self, value: str) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_time", value)
         return self
 
     def get_value_date_time(self) -> str | None:
-        return getattr(self._resource, "value_date_time", None)
+        return cast('str | None', getattr(self._resource, "value_date_time", None))
 
     def set_value_date_time(self, value: str) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_date_time", value)
         return self
 
     def get_value_period(self) -> Period | None:
-        return getattr(self._resource, "value_period", None)
+        return cast('Period | None', getattr(self._resource, "value_period", None))
 
     def set_value_period(self, value: Period) -> "UscoreBodyWeightProfile":
         setattr(self._resource, "value_period", value)
         return self
 
     @overload
-    def get_vscat(self) -> dict | None: ...
+    def get_vscat(self) -> dict[str, Any] | None: ...
     @overload
     def get_vscat(self, mode: Literal["raw"]) -> CodeableConcept | None: ...
-    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict | CodeableConcept | None:
+    def get_vscat(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | CodeableConcept | None:
         match = self.__class__._vscat_slice_match
         item = get_array_slice(getattr(self._resource, "category", None), match)
         if mode == "raw":
-            return item
+            return cast('CodeableConcept | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["coding"])
 
-    def set_vscat(self, value: dict | None = None) -> "UscoreBodyWeightProfile":
+    def set_vscat(self, value: dict[str, Any] | None = None) -> "UscoreBodyWeightProfile":
         match = self.__class__._vscat_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = CodeableConcept(**merged)
@@ -1733,11 +1733,10 @@ exports[`Python US Core Example generates US Core Race extension profile 1`] = `
 
 from __future__ import annotations
 
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 from fhir_types.hl7_fhir_r4_core.base import Extension
 from fhir_types.hl7_fhir_r4_core.base import Extension
-from fhir_types.hl7_fhir_r4_core.base import Coding
 from fhir_types.profile_helpers import (
     _get_key, apply_slice_match, build_resource, ensure_slice_defaults, get_array_slice, get_extension_value, \\
     is_extension, matches_value, push_extension, set_array_slice, strip_match_keys, unwrap_slice_choice, validate_fixed_value, \\
@@ -1759,9 +1758,9 @@ class UscoreRaceExtension:
 
     canonical_url: str = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
 
-    _omb_category_slice_match: dict = {"url":"ombCategory"}
-    _detailed_slice_match: dict = {"url":"detailed"}
-    _text_slice_match: dict = {"url":"text"}
+    _omb_category_slice_match: dict[str, Any] = {"url":"ombCategory"}
+    _detailed_slice_match: dict[str, Any] = {"url":"detailed"}
+    _text_slice_match: dict[str, Any] = {"url":"text"}
 
     def __init__(self, resource: Extension) -> None:
         self._resource = resource
@@ -1792,24 +1791,24 @@ class UscoreRaceExtension:
         return self._resource
 
     def get_extension(self) -> list[Extension] | None:
-        return getattr(self._resource, "extension", None)
+        return cast('list[Extension] | None', getattr(self._resource, "extension", None))
 
     def set_extension(self, value: list[Extension]) -> "UscoreRaceExtension":
         setattr(self._resource, "extension", value)
         return self
 
     def get_url(self) -> str | None:
-        return getattr(self._resource, "url", None)
+        return cast('str | None', getattr(self._resource, "url", None))
 
     def set_url(self, value: str) -> "UscoreRaceExtension":
         setattr(self._resource, "url", value)
         return self
 
     @overload
-    def get_omb_category(self) -> dict | None: ...
+    def get_omb_category(self) -> dict[str, Any] | None: ...
     @overload
     def get_omb_category(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_omb_category(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_omb_category(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "ombCategory")), None)
         if ext is None:
@@ -1817,9 +1816,9 @@ class UscoreRaceExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_omb_category(self, value: "Extension | dict") -> "UscoreRaceExtension":
+    def set_omb_category(self, value: "Extension | dict[str, Any]") -> "UscoreRaceExtension":
         if is_extension(value):
             if _get_key(value, "url") != "ombCategory":
                 raise ValueError(f"Expected extension url 'ombCategory', got {_get_key(value, 'url')!r}")
@@ -1829,10 +1828,10 @@ class UscoreRaceExtension:
         return self
 
     @overload
-    def get_detailed(self) -> dict | None: ...
+    def get_detailed(self) -> dict[str, Any] | None: ...
     @overload
     def get_detailed(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_detailed(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_detailed(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "detailed")), None)
         if ext is None:
@@ -1840,9 +1839,9 @@ class UscoreRaceExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_detailed(self, value: "Extension | dict") -> "UscoreRaceExtension":
+    def set_detailed(self, value: "Extension | dict[str, Any]") -> "UscoreRaceExtension":
         if is_extension(value):
             if _get_key(value, "url") != "detailed":
                 raise ValueError(f"Expected extension url 'detailed', got {_get_key(value, 'url')!r}")
@@ -1852,10 +1851,10 @@ class UscoreRaceExtension:
         return self
 
     @overload
-    def get_text(self) -> dict | None: ...
+    def get_text(self) -> dict[str, Any] | None: ...
     @overload
     def get_text(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_text(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_text(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         exts = getattr(self._resource, "extension", None) or []
         ext = next((e for e in exts if is_extension(e, "text")), None)
         if ext is None:
@@ -1863,9 +1862,9 @@ class UscoreRaceExtension:
         ext_obj = ext if not isinstance(ext, dict) else Extension(**ext)
         if mode == "raw":
             return ext_obj
-        return ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True)
+        return cast("dict[str, Any] | None", ext if isinstance(ext, dict) else ext.model_dump(by_alias=True, exclude_none=True))
 
-    def set_text(self, value: "Extension | dict") -> "UscoreRaceExtension":
+    def set_text(self, value: "Extension | dict[str, Any]") -> "UscoreRaceExtension":
         if is_extension(value):
             if _get_key(value, "url") != "text":
                 raise ValueError(f"Expected extension url 'text', got {_get_key(value, 'url')!r}")
@@ -1875,42 +1874,42 @@ class UscoreRaceExtension:
         return self
 
     @overload
-    def get_extension_omb_category(self) -> Coding | None: ...
+    def get_extension_omb_category(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_omb_category(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_omb_category(self, mode: Literal["raw"] | None = None) -> Coding | Extension | None:
+    def get_extension_omb_category(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._omb_category_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["url"], "valueCoding")
 
     @overload
-    def get_extension_detailed(self) -> Coding | None: ...
+    def get_extension_detailed(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_detailed(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_detailed(self, mode: Literal["raw"] | None = None) -> Coding | Extension | None:
+    def get_extension_detailed(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._detailed_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return unwrap_slice_choice(item_dict, ["url"], "valueCoding")
 
     @overload
-    def get_extension_text(self) -> dict | None: ...
+    def get_extension_text(self) -> dict[str, Any] | None: ...
     @overload
     def get_extension_text(self, mode: Literal["raw"]) -> Extension | None: ...
-    def get_extension_text(self, mode: Literal["raw"] | None = None) -> dict | Extension | None:
+    def get_extension_text(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | Extension | None:
         match = self.__class__._text_slice_match
         item = get_array_slice(getattr(self._resource, "extension", None), match)
         if mode == "raw":
-            return item
+            return cast('Extension | None', item)
         item_dict = item if isinstance(item, dict) else item.model_dump(by_alias=True, exclude_none=True)
         return strip_match_keys(item_dict, ["url"])
 
-    def set_extension_omb_category(self, value: dict | None = None) -> "UscoreRaceExtension":
+    def set_extension_omb_category(self, value: dict[str, Any] | None = None) -> "UscoreRaceExtension":
         match = self.__class__._omb_category_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueCoding")
         merged = apply_slice_match(wrapped, match)
@@ -1920,7 +1919,7 @@ class UscoreRaceExtension:
         setattr(self._resource, "extension", items)
         return self
 
-    def set_extension_detailed(self, value: dict | None = None) -> "UscoreRaceExtension":
+    def set_extension_detailed(self, value: dict[str, Any] | None = None) -> "UscoreRaceExtension":
         match = self.__class__._detailed_slice_match
         wrapped = wrap_slice_choice((value or {}), "valueCoding")
         merged = apply_slice_match(wrapped, match)
@@ -1930,7 +1929,7 @@ class UscoreRaceExtension:
         setattr(self._resource, "extension", items)
         return self
 
-    def set_extension_text(self, value: dict | None = None) -> "UscoreRaceExtension":
+    def set_extension_text(self, value: dict[str, Any] | None = None) -> "UscoreRaceExtension":
         match = self.__class__._text_slice_match
         merged = apply_slice_match((value or {}), match)
         merged = Extension(**merged)
@@ -1967,5 +1966,17 @@ from .patient_uscore_patient_profile import UscorePatientProfile
 from .extension_uscore_race_extension import UscoreRaceExtension
 from .extension_uscore_tribal_affiliation_extension import UscoreTribalAffiliationExtension
 from .observation_uscore_vital_signs_profile import UscoreVitalSignsProfile
+
+__all__ = [
+    'UscoreBloodPressureProfile',
+    'UscoreBodyWeightProfile',
+    'UscoreEthnicityExtension',
+    'UscoreIndividualSexExtension',
+    'UscoreInterpreterNeededExtension',
+    'UscorePatientProfile',
+    'UscoreRaceExtension',
+    'UscoreTribalAffiliationExtension',
+    'UscoreVitalSignsProfile',
+]
 "
 `;


### PR DESCRIPTION
Stacked on #180. Brings the python-us-core example to a clean `mypy` run under **strict mode** (was 250 errors with `--strict`). Closes #181.

## Generator (strict-clean output)
- Emit `dict[str, Any]` instead of bare `dict` — slice match fields, flat slice getters/setters, extension flat get/set — fixing `[type-arg]`.
- Wrap `getattr`/helper returns in `cast(...)` in accessor and slice getters so they don't leak `Any` (`[no-any-return]`). Cast types use **single-quoted** forward-ref strings so they coexist with `Literal["..."]` members.
- Flat slice getters now return `dict[str, Any]` uniformly. Constrained-choice slices unwrap to a dict at runtime, so the prior variant-model annotation (e.g. `-> Quantity`) was inaccurate and tripped `comparison-overlap`.
- Emit `__all__` in the profiles package `__init__.py` for `no_implicit_reexport`.

Before/after (BP systolic getter):
```python
# before
def get_systolic(self, mode: str | None = None) -> Quantity | None:
    return get_array_slice(...)            # returns Any, declares Quantity

# after
@overload
def get_systolic(self) -> dict[str, Any] | None: ...
@overload
def get_systolic(self, mode: Literal["raw"]) -> ObservationComponent | None: ...
def get_systolic(self, mode: Literal["raw"] | None = None) -> dict[str, Any] | ObservationComponent | None:
    return cast('ObservationComponent | None', get_array_slice(...))   # raw branch
```

## Asset
- `profile_helpers.py`: drop 7 now-unused `type: ignore` comments; wrap bool-returning comparisons in `bool()`.

## Tests / demo
- Add `-> None` to test functions (`[no-untyped-def]`).
- Remove stale `type: ignore` comments (raw getters now have overloads; slice setters accept optional input).
- Import `Meta` from `base` (where it's defined) instead of via the `resource` module.

## Config
- `mypy.ini`: `strict = True`. Keeps `strict_optional = False` and the existing `disable_error_code` suppressions — FHIR optional fields and dict/model duality make those checks impractical without pervasive asserts in demo/test code.

```ini
[mypy]
python_version = 3.13
strict = True
strict_optional = False
disable_error_code = assignment, return-value, union-attr, dict-item, index
plugins = pydantic.mypy
```

The Makefile target is unchanged (`mypy --config-file mypy.ini .`) — strict is config-driven, so adding `--strict` on the CLI is unnecessary (and would re-enable `strict_optional`).

## Regenerated
- `fhir_types/` and the python writer snapshots.