### PR TITLE
API: add python client option (fhirpy|none), default fhirpy; deprecate fhirpyClient

### DIFF
--- a/assets/api/writer-generator/python/fhirpy_base_model.py
+++ b/assets/api/writer-generator/python/fhirpy_base_model.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Optional, Iterator, Tuple, Dict
+from typing import TYPE_CHECKING, Any, Union, Optional, Iterator, Tuple, Dict
 from pydantic import BaseModel, Field
 from typing import Protocol
 
@@ -15,6 +15,15 @@ class FhirpyBaseModel(BaseModel):
     after Pydantic finishes model construction, so that fhirpy can detect it
     via cls.resourceType for search/fetch operations.
     """
+
+    if TYPE_CHECKING:
+        # Set at runtime per-subclass by __pydantic_init_subclass__ below. Declared here
+        # so static type-checkers see it: fhirpy's ResourceProtocol requires a settable
+        # `resourceType`, and snake_case models expose the field as `resource_type`
+        # (alias "resourceType"). A settable instance attr (not ClassVar) satisfies the
+        # protocol's mutable member; the default keeps it optional for the pydantic mypy plugin.
+        resourceType: str = ""
+
     id: Optional[str] = Field(None, alias="id")
 
     @classmethod

--- a/src/api/writer-generator/python/writer.ts
+++ b/src/api/writer-generator/python/writer.ts
@@ -79,6 +79,16 @@ export interface PythonGeneratorOptions extends WriterOptions {
     generateProfile?: boolean;
     rootPackageName: string; /// e.g. <rootPackageName>.hl7_fhir_r4_core.Patient.
     fieldFormat: StringFormatKey;
+    /**
+     * Which client integration to generate into the output models.
+     * - `"fhirpy"` — models extend `FhirpyBaseModel` for use with the fhirpy async client (default).
+     * - `"none"` — plain Pydantic models with no client-specific code.
+     */
+    client?: "fhirpy" | "none";
+    /**
+     * @deprecated Use `client` instead: `fhirpyClient: true` → `client: "fhirpy"`,
+     * `fhirpyClient: false` → `client: "none"`.
+     */
     fhirpyClient?: boolean;
 }
 
@@ -105,8 +115,18 @@ export class Python extends Writer<PythonGeneratorOptions> {
     constructor(options: PythonGeneratorOptions) {
         super({ ...options, resolveAssets: options.resolveAssets ?? resolvePyAssets });
         this.nameFormatFunction = this.getFieldFormatFunction(options.fieldFormat);
-        this.forFhirpyClient = options.fhirpyClient ?? false;
+        this.forFhirpyClient = this.resolveClient(options);
         this.fieldFormat = options.fieldFormat;
+    }
+
+    /** Resolve which client integration to emit. `client` wins; `fhirpyClient` is the deprecated fallback; default is fhirpy. */
+    private resolveClient(options: PythonGeneratorOptions): boolean {
+        if (options.client !== undefined) return options.client === "fhirpy";
+        if (options.fhirpyClient !== undefined) {
+            this.logger()?.warn('python: `fhirpyClient` is deprecated; use `client: "fhirpy" | "none"` instead.');
+            return options.fhirpyClient;
+        }
+        return true; // default: fhirpy client
     }
 
     override async generate(tsIndex: TypeSchemaIndex): Promise<void> {

--- a/test/api/write-generator/python.test.ts
+++ b/test/api/write-generator/python.test.ts
@@ -6,6 +6,7 @@ describe("Python Writer Generator", async () => {
     const result = await new APIBuilder({ register: r4Manager, logger: mkErrorLogger() })
         .python({
             inMemoryOnly: true,
+            client: "none",
         })
         .generate();
     expect(result.success).toBeTrue();
@@ -112,6 +113,7 @@ describe("Python R4 Example (with generateProfile)", async () => {
         .python({
             inMemoryOnly: true,
             generateProfile: true,
+            client: "none",
         })
         .generate();
     const files = result.filesGenerated.python!;
@@ -150,6 +152,7 @@ describe("Python US Core Example", async () => {
         .python({
             inMemoryOnly: true,
             generateProfile: true,
+            client: "none",
         })
         .generate();
     const files = result.filesGenerated.python!;
@@ -180,5 +183,32 @@ describe("Python US Core Example", async () => {
 
     it("generates US Core profiles index", () => {
         expect(files["generated/hl7_fhir_us_core/profiles/__init__.py"]).toMatchSnapshot();
+    });
+});
+
+describe("Python client option", async () => {
+    const gen = async (opts: { client?: "fhirpy" | "none"; fhirpyClient?: boolean }) => {
+        const result = await new APIBuilder({ register: r4Manager, logger: mkErrorLogger() })
+            .python({ inMemoryOnly: true, ...opts })
+            .generate();
+        expect(result.success).toBeTrue();
+        return result.filesGenerated.python!;
+    };
+
+    it("defaults to the fhirpy client", async () => {
+        const files = await gen({});
+        expect(files["generated/fhirpy_base_model.py"]).toBeDefined();
+        expect(files["generated/hl7_fhir_r4_core/resource.py"]).toContain("FhirpyBaseModel");
+    });
+
+    it('client: "none" emits plain models with no fhirpy code', async () => {
+        const files = await gen({ client: "none" });
+        expect(files["generated/fhirpy_base_model.py"]).toBeUndefined();
+        expect(files["generated/hl7_fhir_r4_core/resource.py"]).not.toContain("FhirpyBaseModel");
+    });
+
+    it("deprecated fhirpyClient: true still selects the fhirpy client", async () => {
+        const files = await gen({ fhirpyClient: true });
+        expect(files["generated/fhirpy_base_model.py"]).toBeDefined();
     });
 });


### PR DESCRIPTION
Generator/library change extracted from the python-fhirpy-default work (per review): introduce a `client` option for the Python generator and make `fhirpy` the default, plus a type-checking fix for fhirpy + snake_case models.

## `.python({ client })`

Replace the boolean `fhirpyClient` with:

```ts
client?: "fhirpy" | "none"   // default: "fhirpy"
```

- `"fhirpy"` — models extend `FhirpyBaseModel` (fhirpy `AsyncFHIRClient` compatible).
- `"none"` — plain Pydantic models, no client-specific code.
- **`fhirpyClient` is kept and `@deprecated`** — it still works (logs a one-line warning and is translated: `true`→`"fhirpy"`, `false`→`"none"`). Explicit `client` wins.
- **Default is now `"fhirpy"`** — callers that want plain models opt in with `client: "none"`.

```ts
.python({ fhirpyClient: true })   // deprecated
.python({ client: "fhirpy" })     // or just omit it — fhirpy is the default
.python({ client: "none" })       // plain models
```

## fhirpy + snake_case type-checking fix

`FhirpyBaseModel` now declares a `TYPE_CHECKING`-only settable `resourceType: str = ""`. fhirpy's `TResource` is bound to a `ResourceProtocol` with a settable `resourceType`; snake_case models expose the discriminator as `resource_type` (alias `resourceType`) and only set `resourceType` at runtime via `__pydantic_init_subclass__`, which mypy can't see — so fhirpy calls failed type-checking. The annotation is settable (satisfies the protocol bound + class access), defaulted (so the pydantic mypy plugin treats it as optional, not a required ctor arg), and runtime-invisible.

## Tests

- Existing python writer tests made explicit (`client: "none"`) to keep testing plain generation.
- New tests: default → fhirpy (`FhirpyBaseModel` + `fhirpy_base_model.py` present), `"none"` → plain (absent), deprecated `fhirpyClient: true` → fhirpy.
- `tsc` + biome clean; no snapshot changes.

Foundation for the example PRs (#185 / #186); merges independently to `main`.
