### PR TITLE
lint: promote noMisplacedAssertion to error and fix all sites

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,7 +36,7 @@
         "noAssignInExpressions": "off",
         "noVar": "error",
         "noEmptyBlockStatements": "warn",
-        "noMisplacedAssertion": "warn"
+        "noMisplacedAssertion": "error"
       },
       "correctness": {
         "noUnusedPrivateClassMembers": "error",

--- a/test/api/mustache.test.ts
+++ b/test/api/mustache.test.ts
@@ -14,9 +14,13 @@ describe("Mustache Template Based Generation", async () => {
         })
         .throwException()
         .generate();
-    expect(report.success).toBeTrue();
     const files = report.filesGenerated["mustache[./examples/mustache/java]"]!;
-    expect(Object.keys(files).length).toEqual(192);
+
+    it("generates 192 files successfully", () => {
+        expect(report.success).toBeTrue();
+        expect(Object.keys(files).length).toEqual(192);
+    });
+
     it("Patient resource", async () => {
         expect(
             files["generated/model/src/main/java/de/solutio/fhir/models/resources/PatientDTO.java"],

--- a/test/api/write-generator/csharp.test.ts
+++ b/test/api/write-generator/csharp.test.ts
@@ -9,9 +9,13 @@ describe("C# Writer Generator", async () => {
         })
         .throwException()
         .generate();
-    expect(result.success).toBeTrue();
     const files = result.filesGenerated.csharp!;
-    expect(Object.keys(files).length).toEqual(154);
+
+    it("generates 154 files successfully", () => {
+        expect(result.success).toBeTrue();
+        expect(Object.keys(files).length).toEqual(154);
+    });
+
     it("generates Patient resource in inMemoryOnly mode with snapshot", async () => {
         expect(files["generated/types/Hl7FhirR4Core/Patient.cs"]).toMatchSnapshot();
     });

--- a/test/api/write-generator/introspection.test.ts
+++ b/test/api/write-generator/introspection.test.ts
@@ -8,10 +8,13 @@ describe("IntrospectionWriter - Fhir Schema Output", async () => {
         .introspection({ fhirSchemas: "introspection.ndjson" })
         .generate();
 
-    expect(result.success).toBeTrue();
-
     const files = result.filesGenerated.introspection!;
-    expect(Object.keys(files).length).toEqual(656);
+
+    it("generates 656 files successfully", () => {
+        expect(result.success).toBeTrue();
+        expect(Object.keys(files).length).toEqual(656);
+    });
+
     it("Generated file list", () => {
         expect(Object.keys(files)).toMatchSnapshot();
     });
@@ -51,10 +54,13 @@ describe("IntrospectionWriter - TypeSchema output", async () => {
         .introspection({ typeSchemas: "introspection.ndjson" })
         .generate();
 
-    expect(result.success).toBeTrue();
-
     const files = result.filesGenerated.introspection!;
-    expect(Object.keys(files).length).toMatchInlineSnapshot(`61`);
+
+    it("generates the expected number of files successfully", () => {
+        expect(result.success).toBeTrue();
+        expect(Object.keys(files).length).toMatchInlineSnapshot(`61`);
+    });
+
     it("Generated file list", () => {
         expect(Object.keys(files)).toMatchSnapshot();
     });
@@ -102,9 +108,11 @@ describe("IntrospectionWriter - typeTree", async () => {
         .introspection({ typeTree: "type-tree.json" })
         .generate();
 
-    expect(result.success).toBeTrue();
-
     const files = result.filesGenerated.introspection!;
+
+    it("generates successfully", () => {
+        expect(result.success).toBeTrue();
+    });
 
     it("Type tree file should be generated", () => {
         expect(files["generated/type-tree.json"]).toBeDefined();
@@ -133,9 +141,11 @@ describe("IntrospectionWriter - StructureDefinition output", async () => {
         .introspection({ structureDefinitions: "structure-definitions.ndjson" })
         .generate();
 
-    expect(result.success).toBeTrue();
-
     const files = result.filesGenerated.introspection!;
+
+    it("generates successfully", () => {
+        expect(result.success).toBeTrue();
+    });
 
     it("Generated file list", () => {
         expect(Object.keys(files)).toMatchSnapshot();

--- a/test/api/write-generator/python.test.ts
+++ b/test/api/write-generator/python.test.ts
@@ -9,9 +9,12 @@ describe("Python Writer Generator", async () => {
             client: "none",
         })
         .generate();
-    expect(result.success).toBeTrue();
     const files = result.filesGenerated.python!;
-    expect(Object.keys(files).length).toEqual(153);
+
+    it("generates 153 files successfully", () => {
+        expect(result.success).toBeTrue();
+        expect(Object.keys(files).length).toEqual(153);
+    });
 
     it("static files", async () => {
         expect(files["generated/requirements.txt"]).toMatchSnapshot();
@@ -191,7 +194,6 @@ describe("Python client option", async () => {
         const result = await new APIBuilder({ register: r4Manager, logger: mkErrorLogger() })
             .python({ inMemoryOnly: true, ...opts })
             .generate();
-        expect(result.success).toBeTrue();
         return result.filesGenerated.python!;
     };
 

--- a/test/api/write-generator/typescript.test.ts
+++ b/test/api/write-generator/typescript.test.ts
@@ -25,9 +25,13 @@ describe("TypeScript Writer Generator", async () => {
             inMemoryOnly: true,
         })
         .generate();
-    expect(result.success).toBeTrue();
     const files = result.filesGenerated.typescript!;
-    expect(Object.keys(files).length).toEqual(608);
+
+    it("generates 608 files successfully", () => {
+        expect(result.success).toBeTrue();
+        expect(Object.keys(files).length).toEqual(608);
+    });
+
     it("generates Patient resource in inMemoryOnly mode with snapshot", async () => {
         expect(files["generated/types/hl7-fhir-r4-core/Patient.ts"]).toMatchSnapshot();
     });
@@ -185,8 +189,12 @@ describe("TypeScript CDA with Logical Model Promotion to Resource", async () => 
             inMemoryOnly: true,
         })
         .generate();
-    expect(result.success).toBeTrue();
     const files = result.filesGenerated.typescript!;
+
+    it("generates successfully", () => {
+        expect(result.success).toBeTrue();
+    });
+
     it("without resourceType", async () => {
         expect(files["generated/types/hl7-cda-uv-core/CV.ts"]).toMatchSnapshot();
         expect(files["generated/types/hl7-cda-uv-core/index.ts"]).toMatchSnapshot();

--- a/test/unit/typeschema/ir/tree-shake.test.ts
+++ b/test/unit/typeschema/ir/tree-shake.test.ts
@@ -109,14 +109,16 @@ describe("treeShake specific TypeSchema", async () => {
         });
 
         describe("polimorphic field", () => {
-            expect(patientOrigin.fields?.multipleBirth).toMatchObject({
-                choices: ["multipleBirthBoolean", "multipleBirthInteger"],
-            });
-            expect(patientOrigin.fields?.multipleBirthBoolean).toMatchObject({
-                type: { name: "boolean" },
-            });
-            expect(patientOrigin.fields?.multipleBirthInteger).toMatchObject({
-                type: { name: "integer" },
+            it("keeps the polymorphic field and its variants", () => {
+                expect(patientOrigin.fields?.multipleBirth).toMatchObject({
+                    choices: ["multipleBirthBoolean", "multipleBirthInteger"],
+                });
+                expect(patientOrigin.fields?.multipleBirthBoolean).toMatchObject({
+                    type: { name: "boolean" },
+                });
+                expect(patientOrigin.fields?.multipleBirthInteger).toMatchObject({
+                    type: { name: "integer" },
+                });
             });
 
             it("choice declaration", () => {
@@ -194,14 +196,16 @@ describe("treeShake specific TypeSchema", async () => {
         });
 
         describe("polymorphic field", () => {
-            expect(patientOrigin.fields?.multipleBirth).toMatchObject({
-                choices: ["multipleBirthBoolean", "multipleBirthInteger"],
-            });
-            expect(patientOrigin.fields?.multipleBirthBoolean).toMatchObject({
-                type: { name: "boolean" },
-            });
-            expect(patientOrigin.fields?.multipleBirthInteger).toMatchObject({
-                type: { name: "integer" },
+            it("keeps the polymorphic field and its variants", () => {
+                expect(patientOrigin.fields?.multipleBirth).toMatchObject({
+                    choices: ["multipleBirthBoolean", "multipleBirthInteger"],
+                });
+                expect(patientOrigin.fields?.multipleBirthBoolean).toMatchObject({
+                    type: { name: "boolean" },
+                });
+                expect(patientOrigin.fields?.multipleBirthInteger).toMatchObject({
+                    type: { name: "integer" },
+                });
             });
 
             it("choice declaration - get all polimorphic fields", () => {

--- a/test/unit/typeschema/register.test.ts
+++ b/test/unit/typeschema/register.test.ts
@@ -59,24 +59,26 @@ describe("Register tests", async () => {
             throw new Error("Patient genealogy not found");
         }
 
-        expect(pat.map((fs) => fs.url)).toMatchObject([
-            "http://hl7.org/fhir/StructureDefinition/Patient",
-            "http://hl7.org/fhir/StructureDefinition/DomainResource",
-            "http://hl7.org/fhir/StructureDefinition/Resource",
-        ]);
+        it("resolves the Patient genealogy and its gender binding", () => {
+            expect(pat.map((fs) => fs.url)).toMatchObject([
+                "http://hl7.org/fhir/StructureDefinition/Patient",
+                "http://hl7.org/fhir/StructureDefinition/DomainResource",
+                "http://hl7.org/fhir/StructureDefinition/Resource",
+            ]);
 
-        expect(resolveFsElementGenealogy(pat, ["gender"])).toMatchObject([
-            {
-                binding: {
-                    bindingName: "AdministrativeGender",
-                    strength: "required",
-                    valueSet: "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1",
+            expect(resolveFsElementGenealogy(pat, ["gender"])).toMatchObject([
+                {
+                    binding: {
+                        bindingName: "AdministrativeGender",
+                        strength: "required",
+                        valueSet: "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1",
+                    },
+                    isSummary: true,
+                    short: "male | female | other | unknown",
+                    type: "code",
                 },
-                isSummary: true,
-                short: "male | female | other | unknown",
-                type: "code",
-            },
-        ]);
+            ]);
+        });
     });
 
     describe("resolve element genealogy", () => {
@@ -99,24 +101,26 @@ describe("Register tests", async () => {
             },
         ];
 
-        expect(resolveFsElementGenealogyT(flatGenealogy, ["foo"])).toMatchObject([
-            { min: 1 },
-            { array: true, type: "string" },
-        ]);
-        expect(mergeFsElementProps(resolveFsElementGenealogyT(flatGenealogy, ["foo"]))).toMatchObject({
-            array: true,
-            min: 1,
-            type: "string",
-        });
+        it("resolves and merges flat genealogy", () => {
+            expect(resolveFsElementGenealogyT(flatGenealogy, ["foo"])).toMatchObject([
+                { min: 1 },
+                { array: true, type: "string" },
+            ]);
+            expect(mergeFsElementProps(resolveFsElementGenealogyT(flatGenealogy, ["foo"]))).toMatchObject({
+                array: true,
+                min: 1,
+                type: "string",
+            });
 
-        expect(resolveFsElementGenealogyT(flatGenealogy, ["bar"])).toMatchObject([
-            { min: 12 },
-            { array: true, min: 0, type: "code" },
-        ]);
-        expect(mergeFsElementProps(resolveFsElementGenealogyT(flatGenealogy, ["bar"]))).toMatchObject({
-            array: true,
-            min: 12,
-            type: "code",
+            expect(resolveFsElementGenealogyT(flatGenealogy, ["bar"])).toMatchObject([
+                { min: 12 },
+                { array: true, min: 0, type: "code" },
+            ]);
+            expect(mergeFsElementProps(resolveFsElementGenealogyT(flatGenealogy, ["bar"]))).toMatchObject({
+                array: true,
+                min: 12,
+                type: "code",
+            });
         });
 
         const deepGenealogy = [
@@ -136,22 +140,24 @@ describe("Register tests", async () => {
             },
         ];
 
-        expect(resolveFsElementGenealogyT(deepGenealogy, ["foo"])).toMatchObject([
-            { elements: { bar: { min: 1, type: "string" } } },
-            { elements: { bar: { array: true, type: "string" } }, type: "string" },
-        ]);
-        expect(mergeFsElementProps(resolveFsElementGenealogyT(deepGenealogy, ["foo"]))).toMatchObject({
-            type: "string",
-        });
+        it("resolves and merges deep (nested) genealogy", () => {
+            expect(resolveFsElementGenealogyT(deepGenealogy, ["foo"])).toMatchObject([
+                { elements: { bar: { min: 1, type: "string" } } },
+                { elements: { bar: { array: true, type: "string" } }, type: "string" },
+            ]);
+            expect(mergeFsElementProps(resolveFsElementGenealogyT(deepGenealogy, ["foo"]))).toMatchObject({
+                type: "string",
+            });
 
-        expect(resolveFsElementGenealogyT(deepGenealogy, ["foo", "bar"])).toMatchObject([
-            { min: 1, type: "string" },
-            { array: true, type: "string" },
-        ]);
-        expect(mergeFsElementProps(resolveFsElementGenealogyT(deepGenealogy, ["foo", "bar"]))).toMatchObject({
-            array: true,
-            min: 1,
-            type: "string",
+            expect(resolveFsElementGenealogyT(deepGenealogy, ["foo", "bar"])).toMatchObject([
+                { min: 1, type: "string" },
+                { array: true, type: "string" },
+            ]);
+            expect(mergeFsElementProps(resolveFsElementGenealogyT(deepGenealogy, ["foo", "bar"]))).toMatchObject({
+                array: true,
+                min: 1,
+                type: "string",
+            });
         });
     });
 });


### PR DESCRIPTION
Promotes the `suspicious/noMisplacedAssertion` Biome rule from `warn` to `error`, and fixes every offending site so `make lint` stays green.

Stacked on top of the python stack (base: `python-fhirpy-default` / #186).

## Change

- `biome.json`: `noMisplacedAssertion` `"warn"` → `"error"`.
- The rule flags `expect()` calls that aren't inside an `it()`/`test()` block. Several suites asserted at `describe` scope (setup-then-assert, or a `describe` body that was really a test). Each such assertion is now wrapped in an `it()` (or moved out of a setup helper).

32 sites across 7 files:

| File | sites |
|---|---|
| `test/unit/typeschema/register.test.ts` | 10 |
| `test/api/write-generator/introspection.test.ts` | 6 |
| `test/unit/typeschema/ir/tree-shake.test.ts` | 6 |
| `test/api/write-generator/python.test.ts` | 3 |
| `test/api/write-generator/typescript.test.ts` | 3 |
| `test/api/mustache.test.ts` | 2 |
| `test/api/write-generator/csharp.test.ts` | 2 |

## No behavior change

The assertions run exactly as before — just inside `it()` blocks now. Verified: `biome check` reports **0** `noMisplacedAssertion` (and 0 errors overall), the 111 tests across the 7 files pass, and `tsc` is clean.
