### PR TITLE
PY: generate resourceType as str instead of Literal

### DIFF
--- a/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/bundle.py
+++ b/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/bundle.py
@@ -71,7 +71,7 @@ class BundleLink(BackboneElement):
 
 class Bundle(Resource, Generic[T1, T2]):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Bundle'] = Field(
+    resourceType: str = Field(
         default='Bundle',
         alias='resourceType',
         serialization_alias='resourceType',

--- a/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/observation.py
+++ b/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/observation.py
@@ -46,7 +46,7 @@ class ObservationReferenceRange(BackboneElement):
 
 class Observation(DomainResource):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Observation'] = Field(
+    resourceType: str = Field(
         default='Observation',
         alias='resourceType',
         serialization_alias='resourceType',

--- a/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/operation_outcome.py
+++ b/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/operation_outcome.py
@@ -24,7 +24,7 @@ class OperationOutcomeIssue(BackboneElement):
 
 class OperationOutcome(DomainResource):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['OperationOutcome'] = Field(
+    resourceType: str = Field(
         default='OperationOutcome',
         alias='resourceType',
         serialization_alias='resourceType',

--- a/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/organization.py
+++ b/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/organization.py
@@ -25,7 +25,7 @@ class OrganizationContact(BackboneElement):
 
 class Organization(DomainResource):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Organization'] = Field(
+    resourceType: str = Field(
         default='Organization',
         alias='resourceType',
         serialization_alias='resourceType',

--- a/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/patient.py
+++ b/examples/python-r4-us-core/fhir_types/hl7_fhir_r4_core/patient.py
@@ -38,7 +38,7 @@ class PatientLink(BackboneElement):
 
 class Patient(DomainResource):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Patient'] = Field(
+    resourceType: str = Field(
         default='Patient',
         alias='resourceType',
         serialization_alias='resourceType',

--- a/src/api/writer-generator/python/writer.ts
+++ b/src/api/writer-generator/python/writer.ts
@@ -468,13 +468,9 @@ export class Python extends Writer<PythonGeneratorOptions> {
     }
 
     private generateResourceTypeField(schema: SpecializationTypeSchema): void {
-        const hasChildren = (schema.typeFamily?.resources?.length ?? 0) > 0;
-
-        if (hasChildren) {
-            this.line(`${this.nameFormatFunction("resourceType")}: str = Field(`);
-        } else {
-            this.line(`${this.nameFormatFunction("resourceType")}: Literal['${schema.identifier.name}'] = Field(`);
-        }
+        // Always type as `str`; the value is validated on the pydantic side via `pattern`.
+        // A `Literal[...]` here would shadow the parent's field and trigger Pydantic warnings.
+        this.line(`${this.nameFormatFunction("resourceType")}: str = Field(`);
         this.indentBlock(() => {
             this.line(`default='${schema.identifier.name}',`);
             this.line(`alias='resourceType',`);

--- a/test/api/write-generator/__snapshots__/python.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/python.test.ts.snap
@@ -83,7 +83,7 @@ class BundleLink(BackboneElement):
 
 class Bundle(Resource, Generic[T1, T2]):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Bundle'] = Field(
+    resourceType: str = Field(
         default='Bundle',
         alias='resourceType',
         serialization_alias='resourceType',
@@ -157,7 +157,7 @@ class PatientLink(BackboneElement):
 
 class Patient(DomainResource):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Patient'] = Field(
+    resourceType: str = Field(
         default='Patient',
         alias='resourceType',
         serialization_alias='resourceType',
@@ -268,7 +268,7 @@ class BundleLink(BackboneElement):
 
 class Bundle(Resource, Generic[T1, T2]):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Bundle'] = Field(
+    resourceType: str = Field(
         default='Bundle',
         alias='resourceType',
         serialization_alias='resourceType',
@@ -375,7 +375,7 @@ class BundleLink(BackboneElement):
 
 class Bundle(Resource, Generic[T1, T2]):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Bundle'] = Field(
+    resourceType: str = Field(
         default='Bundle',
         alias='resourceType',
         serialization_alias='resourceType',

--- a/test/api/write-generator/multi-package/__snapshots__/cda.test.ts.snap
+++ b/test/api/write-generator/multi-package/__snapshots__/cda.test.ts.snap
@@ -92,7 +92,7 @@ T2 = TypeVar('T2', bound=ANY, default=ANY)
 
 class ClinicalDocument(ANY, Generic[T1, T2]):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['ClinicalDocument'] = Field(
+    resourceType: str = Field(
         default='ClinicalDocument',
         alias='resourceType',
         serialization_alias='resourceType',

--- a/test/api/write-generator/multi-package/__snapshots__/local-package.test.ts.snap
+++ b/test/api/write-generator/multi-package/__snapshots__/local-package.test.ts.snap
@@ -210,7 +210,7 @@ from fhir_types.hl7_fhir_r4_core.domain_resource import DomainResource
 
 class ExampleNotebook(DomainResource):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['ExampleNotebook'] = Field(
+    resourceType: str = Field(
         default='ExampleNotebook',
         alias='resourceType',
         serialization_alias='resourceType',
@@ -326,7 +326,7 @@ class PatientLink(BackboneElement):
 
 class Patient(DomainResource):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['Patient'] = Field(
+    resourceType: str = Field(
         default='Patient',
         alias='resourceType',
         serialization_alias='resourceType',

--- a/test/api/write-generator/multi-package/__snapshots__/sql-on-fhir.test.ts.snap
+++ b/test/api/write-generator/multi-package/__snapshots__/sql-on-fhir.test.ts.snap
@@ -148,7 +148,7 @@ class ViewDefinitionWhere(BackboneElement):
 
 class ViewDefinition(CanonicalResource):
     model_config = ConfigDict(validate_by_name=True, serialize_by_alias=True, extra="forbid")
-    resourceType: Literal['ViewDefinition'] = Field(
+    resourceType: str = Field(
         default='ViewDefinition',
         alias='resourceType',
         serialization_alias='resourceType',


### PR DESCRIPTION
Generate the `resourceType` field as `str` instead of a per-resource `Literal[...]`. The value is still validated on the Pydantic side via `Field(pattern=...)`; a per-subclass `Literal` narrows the parent field and is redundant with the pattern.

Before:

```python
class Observation(DomainResource):
    resourceType: Literal['Observation'] = Field(
        default='Observation',
        alias='resourceType',
        serialization_alias='resourceType',
        pattern='Observation'
    )
```

After:

```python
class Observation(DomainResource):
    resourceType: str = Field(
        default='Observation',
        alias='resourceType',
        serialization_alias='resourceType',
        pattern='Observation'
    )
```

- Update Python writer + multi-package snapshots (`cda`, `sql-on-fhir`, `local-package`).
- Regenerate the `python-r4-us-core` example.

---

Follow-up: shadow-warning fix split into #191.