### PR TITLE
API/TypeSchema: respect tree shaking and fix package attribution in introspection output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.7",
     "esbuild": ">=0.28.1",
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
@@ -281,7 +281,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/examples/python-r4-us-core/fhir_types/README.md
+++ b/examples/python-r4-us-core/fhir_types/README.md
@@ -3626,8 +3626,8 @@ and check `<pkg>/collisions/<name>/1.json, 2.json, ...` files.
   - Version 3: Consent (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:ConsentContentClass` (4 versions)
   - Version 1 (auto): Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1)
-  - Version 2: Contract (hl7.fhir.r5.core#5.0.0), Contract (hl7.fhir.r5.core#5.0.0), Contract (hl7.fhir.r5.core#5.0.0)
-  - Version 3: Consent (hl7.fhir.r5.core#5.0.0), Consent (hl7.fhir.r5.core#5.0.0), Consent (hl7.fhir.r5.core#5.0.0)
+  - Version 2: Consent (hl7.fhir.r5.core#5.0.0), Consent (hl7.fhir.r5.core#5.0.0), Consent (hl7.fhir.r5.core#5.0.0)
+  - Version 3: Contract (hl7.fhir.r5.core#5.0.0), Contract (hl7.fhir.r5.core#5.0.0), Contract (hl7.fhir.r5.core#5.0.0)
   - Version 4: Consent (hl7.fhir.r4.examples#4.0.1), Contract (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:ConsentContentCode` (3 versions)
   - Version 1 (auto): Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1)
@@ -4165,8 +4165,8 @@ and check `<pkg>/collisions/<name>/1.json, 2.json, ...` files.
   - Version 3: FamilyMemberHistory (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:FHIRAllTypes` (3 versions)
   - Version 1 (auto): DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1)
-  - Version 2: OperationDefinition (hl7.fhir.r5.core#5.0.0), OperationDefinition (hl7.fhir.r5.core#5.0.0), OperationDefinition (hl7.fhir.r5.core#5.0.0)
-  - Version 3: DataRequirement (hl7.fhir.r4.examples#4.0.1), OperationDefinition (hl7.fhir.r4.examples#4.0.1), ParameterDefinition (hl7.fhir.r4.examples#4.0.1)
+  - Version 2: DataRequirement (hl7.fhir.r4.examples#4.0.1), OperationDefinition (hl7.fhir.r4.examples#4.0.1), ParameterDefinition (hl7.fhir.r4.examples#4.0.1)
+  - Version 3: OperationDefinition (hl7.fhir.r5.core#5.0.0), OperationDefinition (hl7.fhir.r5.core#5.0.0), OperationDefinition (hl7.fhir.r5.core#5.0.0)
 - `urn:fhir:binding:FHIRDefinedType` (2 versions)
   - Version 1 (auto): TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1)
   - Version 2: TestScript (hl7.fhir.r4.examples#4.0.1)
@@ -4718,8 +4718,8 @@ and check `<pkg>/collisions/<name>/1.json, 2.json, ...` files.
 - `urn:fhir:binding:NoteType` (4 versions)
   - Version 1 (auto): ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1)
   - Version 2: ClaimResponse (hl7.fhir.r5.core#5.0.0), ClaimResponse (hl7.fhir.r5.core#5.0.0), ClaimResponse (hl7.fhir.r5.core#5.0.0), ExplanationOfBenefit (hl7.fhir.r5.core#5.0.0), ExplanationOfBenefit (hl7.fhir.r5.core#5.0.0), ExplanationOfBenefit (hl7.fhir.r5.core#5.0.0)
-  - Version 3: PaymentReconciliation (hl7.fhir.r5.core#5.0.0), PaymentReconciliation (hl7.fhir.r5.core#5.0.0), PaymentReconciliation (hl7.fhir.r5.core#5.0.0)
-  - Version 4: ClaimResponse (hl7.fhir.r4.examples#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.examples#4.0.1), PaymentReconciliation (hl7.fhir.r4.examples#4.0.1)
+  - Version 3: ClaimResponse (hl7.fhir.r4.examples#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.examples#4.0.1), PaymentReconciliation (hl7.fhir.r4.examples#4.0.1)
+  - Version 4: PaymentReconciliation (hl7.fhir.r5.core#5.0.0), PaymentReconciliation (hl7.fhir.r5.core#5.0.0), PaymentReconciliation (hl7.fhir.r5.core#5.0.0)
 - `urn:fhir:binding:NutrientModifier` (3 versions)
   - Version 1 (auto): NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1)
   - Version 2: NutritionOrder (hl7.fhir.r5.core#5.0.0), NutritionOrder (hl7.fhir.r5.core#5.0.0), NutritionOrder (hl7.fhir.r5.core#5.0.0)
@@ -5540,8 +5540,8 @@ and check `<pkg>/collisions/<name>/1.json, 2.json, ...` files.
   - Version 3: Timing (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:UsageContextType` (4 versions)
   - Version 1 (auto): UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), sdc-usagecontext (hl7.fhir.uv.sdc#3.0.0), sdc-usagecontext (hl7.fhir.uv.sdc#3.0.0)
-  - Version 2: UsageContext (hl7.fhir.r5.core#5.0.0), UsageContext (hl7.fhir.r5.core#5.0.0), UsageContext (hl7.fhir.r5.core#5.0.0)
-  - Version 3: EvidenceVariable (hl7.fhir.r5.core#5.0.0), EvidenceVariable (hl7.fhir.r5.core#5.0.0), EvidenceVariable (hl7.fhir.r5.core#5.0.0)
+  - Version 2: EvidenceVariable (hl7.fhir.r5.core#5.0.0), EvidenceVariable (hl7.fhir.r5.core#5.0.0), EvidenceVariable (hl7.fhir.r5.core#5.0.0)
+  - Version 3: UsageContext (hl7.fhir.r5.core#5.0.0), UsageContext (hl7.fhir.r5.core#5.0.0), UsageContext (hl7.fhir.r5.core#5.0.0)
   - Version 4: UsageContext (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:Use` (3 versions)
   - Version 1 (auto): Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1)
@@ -5694,7 +5694,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:AdjunctDiagnosis": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/lipidprofile",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
         },
         "urn:fhir:binding:AdministrativeGender": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5858,7 +5858,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:BenefitCategory": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Claim",
         },
         "urn:fhir:binding:BenefitCostApplicability": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5882,7 +5882,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:BindingStrength": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/OperationDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ElementDefinition",
         },
         "urn:fhir:binding:BiologicallyDerivedProductCategory": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5902,11 +5902,11 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:BodyLengthUnits": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/headcircum",
+            canonical: "http://hl7.org/fhir/StructureDefinition/bodyheight",
         },
         "urn:fhir:binding:BodySite": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:BodyStructureCode": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5926,7 +5926,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:BundleType": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/transaction-bundle",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Bundle",
         },
         "urn:fhir:binding:can-push-updates": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5961,8 +5961,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/CarePlan",
         },
         "urn:fhir:binding:CarePlanCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/CarePlan",
         },
         "urn:fhir:binding:CarePlanIntent": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6138,7 +6138,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ConceptDesignationUse": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/ValueSet",
+            canonical: "http://hl7.org/fhir/StructureDefinition/CodeSystem",
         },
         "urn:fhir:binding:ConceptMapEquivalence": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6157,8 +6157,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/CapabilityStatement",
         },
         "urn:fhir:binding:ConditionCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Condition",
         },
         "urn:fhir:binding:ConditionClinicalStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6206,7 +6206,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ConsentContentClass": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Contract",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Consent",
         },
         "urn:fhir:binding:ConsentContentCode": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6405,8 +6405,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Coverage",
         },
         "urn:fhir:binding:CoverageStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-coverage",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Coverage",
         },
         "urn:fhir:binding:CoverageType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6422,11 +6422,11 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DaysOfWeek": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+            canonical: "http://hl7.org/fhir/StructureDefinition/HealthcareService",
         },
         "urn:fhir:binding:DefinitionTopic": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EventDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:DetectedIssueCategory": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6478,7 +6478,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DeviceNameType": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/DeviceDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Device",
         },
         "urn:fhir:binding:DeviceRequestParticipantRole": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6510,7 +6510,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DiagnosisRole": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:DiagnosisType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6518,15 +6518,15 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DiagnosticReportCodes": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/lipidprofile",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
         },
         "urn:fhir:binding:DiagnosticReportStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
         },
         "urn:fhir:binding:DiagnosticServiceSection": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
         },
         "urn:fhir:binding:DICOMMediaType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6541,8 +6541,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/ElementDefinition",
         },
         "urn:fhir:binding:DocumentC80Class": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-adi-documentreference",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DocumentReference",
         },
         "urn:fhir:binding:DocumentC80FacilityType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6578,7 +6578,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DocumentReferenceStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DocumentManifest",
         },
         "urn:fhir:binding:DocumentRelationshipType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6621,24 +6621,24 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Questionnaire",
         },
         "urn:fhir:binding:EncounterClass": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterLocationStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterReason": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterServiceType": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6750,7 +6750,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:FamilialRelationship": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/familymemberhistory-genetic",
+            canonical: "http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory",
         },
         "urn:fhir:binding:FamilyHistoryAbsentReason": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6798,7 +6798,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:FHIRTypes": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/OperationDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/GraphDefinition",
         },
         "urn:fhir:binding:FHIRVersion": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6806,7 +6806,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:FilterOperator": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/ValueSet",
+            canonical: "http://hl7.org/fhir/StructureDefinition/CodeSystem",
         },
         "urn:fhir:binding:FlagCategory": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7026,11 +7026,11 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:Jurisdiction": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EventDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:Language": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/ValueSet",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Attachment",
         },
         "urn:fhir:binding:Laterality": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7042,7 +7042,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:LibraryType": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/modelinfolibrary",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Library",
         },
         "urn:fhir:binding:LinkageType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7081,8 +7081,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Location",
         },
         "urn:fhir:binding:LocationStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Location",
         },
         "urn:fhir:binding:LocationType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7193,8 +7193,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
         },
         "urn:fhir:binding:MedicationDispenseStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationdispense",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
         },
         "urn:fhir:binding:MedicationDispenseType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7202,15 +7202,15 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:MedicationForm": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationKnowledge",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Medication",
         },
         "urn:fhir:binding:MedicationFormalRepresentation": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationKnowledge",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Medication",
         },
         "urn:fhir:binding:MedicationIntendedSubstitutionReason": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
         },
         "urn:fhir:binding:MedicationIntendedSubstitutionType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7229,8 +7229,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
         },
         "urn:fhir:binding:MedicationRequestCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
         },
         "urn:fhir:binding:MedicationRequestCourseOfTherapy": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7306,7 +7306,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:MimeType": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Binary",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Attachment",
         },
         "urn:fhir:binding:MissingReason": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7314,7 +7314,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:Modifiers": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Claim",
         },
         "urn:fhir:binding:NameUse": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7353,12 +7353,12 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
         },
         "urn:fhir:binding:ObservationCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-average-blood-pressure",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:ObservationCode": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-average-blood-pressure",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:ObservationDataType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7389,16 +7389,16 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:ObservationStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-average-blood-pressure",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:ObservationUnit": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/ObservationDefinition",
         },
         "urn:fhir:binding:ObservationValueAbsentReason": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-average-blood-pressure",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:OperationalStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7453,8 +7453,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/AppointmentResponse",
         },
         "urn:fhir:binding:ParticipantType": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Appointment",
         },
         "urn:fhir:binding:ParticipationStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7462,7 +7462,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:PatientDiet": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:PatientRelationshipType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7498,7 +7498,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:PhysicalType": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Location",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:PlanDefinitionType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7574,7 +7574,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ProcessPriority": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Claim",
         },
         "urn:fhir:binding:Program": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7630,7 +7630,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:PublicationStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EventDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:PurposeOfUse": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7662,7 +7662,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:QuantityComparator": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/SimpleQuantity",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Quantity",
         },
         "urn:fhir:binding:QuestionnaireConcept": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7677,8 +7677,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Questionnaire",
         },
         "urn:fhir:binding:QuestionnaireResponseStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
         },
         "urn:fhir:binding:ReAdmissionType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7718,7 +7718,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:RemittanceOutcome": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EnrollmentResponse",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ClaimResponse",
         },
         "urn:fhir:binding:repositoryType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7730,7 +7730,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:RequestPriority": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:RequestStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7802,7 +7802,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:RouteOfAdministration": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Dosage",
+            canonical: "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance",
         },
         "urn:fhir:binding:Safety": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7862,23 +7862,23 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ServiceProduct": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Claim",
         },
         "urn:fhir:binding:ServiceProvisionConditions": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/HealthcareService",
         },
         "urn:fhir:binding:ServiceRequestCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:ServiceRequestCode": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:ServiceRequestIntent": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:ServiceRequestLocation": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7897,12 +7897,12 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:ServiceRequestStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:Sex": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/familymemberhistory-genetic",
+            canonical: "http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory",
         },
         "urn:fhir:binding:SignatureType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7965,8 +7965,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/VerificationResult",
         },
         "urn:fhir:binding:Status": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/vitalsigns",
         },
         "urn:fhir:binding:strandType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -8034,7 +8034,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:SubstanceCode": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Substance",
+            canonical: "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance",
         },
         "urn:fhir:binding:SupplementType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -8218,7 +8218,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:VitalSigns": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+            canonical: "http://hl7.org/fhir/StructureDefinition/bmi",
         },
         "urn:fhir:binding:XPathUsageType": {
             package: "hl7.fhir.r4.core#4.0.1",

--- a/examples/typescript-r4-us-core/fhir-types/README.md
+++ b/examples/typescript-r4-us-core/fhir-types/README.md
@@ -3620,8 +3620,8 @@ and check `<pkg>/collisions/<name>/1.json, 2.json, ...` files.
   - Version 3: Consent (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:ConsentContentClass` (4 versions)
   - Version 1 (auto): Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1), Contract (hl7.fhir.r4.core#4.0.1)
-  - Version 2: Contract (hl7.fhir.r5.core#5.0.0), Contract (hl7.fhir.r5.core#5.0.0), Contract (hl7.fhir.r5.core#5.0.0)
-  - Version 3: Consent (hl7.fhir.r5.core#5.0.0), Consent (hl7.fhir.r5.core#5.0.0), Consent (hl7.fhir.r5.core#5.0.0)
+  - Version 2: Consent (hl7.fhir.r5.core#5.0.0), Consent (hl7.fhir.r5.core#5.0.0), Consent (hl7.fhir.r5.core#5.0.0)
+  - Version 3: Contract (hl7.fhir.r5.core#5.0.0), Contract (hl7.fhir.r5.core#5.0.0), Contract (hl7.fhir.r5.core#5.0.0)
   - Version 4: Consent (hl7.fhir.r4.examples#4.0.1), Contract (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:ConsentContentCode` (3 versions)
   - Version 1 (auto): Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1), Consent (hl7.fhir.r4.core#4.0.1)
@@ -4159,8 +4159,8 @@ and check `<pkg>/collisions/<name>/1.json, 2.json, ...` files.
   - Version 3: FamilyMemberHistory (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:FHIRAllTypes` (3 versions)
   - Version 1 (auto): DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), DataRequirement (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), OperationDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1), ParameterDefinition (hl7.fhir.r4.core#4.0.1)
-  - Version 2: OperationDefinition (hl7.fhir.r5.core#5.0.0), OperationDefinition (hl7.fhir.r5.core#5.0.0), OperationDefinition (hl7.fhir.r5.core#5.0.0)
-  - Version 3: DataRequirement (hl7.fhir.r4.examples#4.0.1), OperationDefinition (hl7.fhir.r4.examples#4.0.1), ParameterDefinition (hl7.fhir.r4.examples#4.0.1)
+  - Version 2: DataRequirement (hl7.fhir.r4.examples#4.0.1), OperationDefinition (hl7.fhir.r4.examples#4.0.1), ParameterDefinition (hl7.fhir.r4.examples#4.0.1)
+  - Version 3: OperationDefinition (hl7.fhir.r5.core#5.0.0), OperationDefinition (hl7.fhir.r5.core#5.0.0), OperationDefinition (hl7.fhir.r5.core#5.0.0)
 - `urn:fhir:binding:FHIRDefinedType` (2 versions)
   - Version 1 (auto): TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1), TestScript (hl7.fhir.r4.core#4.0.1)
   - Version 2: TestScript (hl7.fhir.r4.examples#4.0.1)
@@ -4712,8 +4712,8 @@ and check `<pkg>/collisions/<name>/1.json, 2.json, ...` files.
 - `urn:fhir:binding:NoteType` (4 versions)
   - Version 1 (auto): ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1), PaymentReconciliation (hl7.fhir.r4.core#4.0.1)
   - Version 2: ClaimResponse (hl7.fhir.r5.core#5.0.0), ClaimResponse (hl7.fhir.r5.core#5.0.0), ClaimResponse (hl7.fhir.r5.core#5.0.0), ExplanationOfBenefit (hl7.fhir.r5.core#5.0.0), ExplanationOfBenefit (hl7.fhir.r5.core#5.0.0), ExplanationOfBenefit (hl7.fhir.r5.core#5.0.0)
-  - Version 3: PaymentReconciliation (hl7.fhir.r5.core#5.0.0), PaymentReconciliation (hl7.fhir.r5.core#5.0.0), PaymentReconciliation (hl7.fhir.r5.core#5.0.0)
-  - Version 4: ClaimResponse (hl7.fhir.r4.examples#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.examples#4.0.1), PaymentReconciliation (hl7.fhir.r4.examples#4.0.1)
+  - Version 3: ClaimResponse (hl7.fhir.r4.examples#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.examples#4.0.1), PaymentReconciliation (hl7.fhir.r4.examples#4.0.1)
+  - Version 4: PaymentReconciliation (hl7.fhir.r5.core#5.0.0), PaymentReconciliation (hl7.fhir.r5.core#5.0.0), PaymentReconciliation (hl7.fhir.r5.core#5.0.0)
 - `urn:fhir:binding:NutrientModifier` (3 versions)
   - Version 1 (auto): NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1), NutritionOrder (hl7.fhir.r4.core#4.0.1)
   - Version 2: NutritionOrder (hl7.fhir.r5.core#5.0.0), NutritionOrder (hl7.fhir.r5.core#5.0.0), NutritionOrder (hl7.fhir.r5.core#5.0.0)
@@ -5534,8 +5534,8 @@ and check `<pkg>/collisions/<name>/1.json, 2.json, ...` files.
   - Version 3: Timing (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:UsageContextType` (4 versions)
   - Version 1 (auto): UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), UsageContext (hl7.fhir.r4.core#4.0.1), sdc-usagecontext (hl7.fhir.uv.sdc#3.0.0), sdc-usagecontext (hl7.fhir.uv.sdc#3.0.0)
-  - Version 2: UsageContext (hl7.fhir.r5.core#5.0.0), UsageContext (hl7.fhir.r5.core#5.0.0), UsageContext (hl7.fhir.r5.core#5.0.0)
-  - Version 3: EvidenceVariable (hl7.fhir.r5.core#5.0.0), EvidenceVariable (hl7.fhir.r5.core#5.0.0), EvidenceVariable (hl7.fhir.r5.core#5.0.0)
+  - Version 2: EvidenceVariable (hl7.fhir.r5.core#5.0.0), EvidenceVariable (hl7.fhir.r5.core#5.0.0), EvidenceVariable (hl7.fhir.r5.core#5.0.0)
+  - Version 3: UsageContext (hl7.fhir.r5.core#5.0.0), UsageContext (hl7.fhir.r5.core#5.0.0), UsageContext (hl7.fhir.r5.core#5.0.0)
   - Version 4: UsageContext (hl7.fhir.r4.examples#4.0.1)
 - `urn:fhir:binding:Use` (3 versions)
   - Version 1 (auto): Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), Claim (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ClaimResponse (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1), ExplanationOfBenefit (hl7.fhir.r4.core#4.0.1)
@@ -5660,7 +5660,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ActivityParticipantType": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/RequestOrchestration",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:AdditionalInstruction": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5688,7 +5688,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:AdjunctDiagnosis": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/lipidprofile",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
         },
         "urn:fhir:binding:AdministrativeGender": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5852,7 +5852,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:BenefitCategory": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Claim",
         },
         "urn:fhir:binding:BenefitCostApplicability": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5876,7 +5876,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:BindingStrength": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/OperationDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ElementDefinition",
         },
         "urn:fhir:binding:BiologicallyDerivedProductCategory": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5896,11 +5896,11 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:BodyLengthUnits": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/headcircum",
+            canonical: "http://hl7.org/fhir/StructureDefinition/bodyheight",
         },
         "urn:fhir:binding:BodySite": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:BodyStructureCode": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5920,7 +5920,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:BundleType": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/transaction-bundle",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Bundle",
         },
         "urn:fhir:binding:can-push-updates": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -5955,8 +5955,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/CarePlan",
         },
         "urn:fhir:binding:CarePlanCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/CarePlan",
         },
         "urn:fhir:binding:CarePlanIntent": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6128,7 +6128,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ConceptDesignationUse": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/ValueSet",
+            canonical: "http://hl7.org/fhir/StructureDefinition/CodeSystem",
         },
         "urn:fhir:binding:ConceptMapEquivalence": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6147,8 +6147,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/CapabilityStatement",
         },
         "urn:fhir:binding:ConditionCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Condition",
         },
         "urn:fhir:binding:ConditionClinicalStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6196,7 +6196,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ConsentContentClass": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Contract",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Consent",
         },
         "urn:fhir:binding:ConsentContentCode": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6395,8 +6395,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Coverage",
         },
         "urn:fhir:binding:CoverageStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-coverage",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Coverage",
         },
         "urn:fhir:binding:CoverageType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6412,11 +6412,11 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DaysOfWeek": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+            canonical: "http://hl7.org/fhir/StructureDefinition/HealthcareService",
         },
         "urn:fhir:binding:DefinitionTopic": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EventDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:DetectedIssueCategory": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6468,7 +6468,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DeviceNameType": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/DeviceDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Device",
         },
         "urn:fhir:binding:DeviceRequestParticipantRole": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6500,7 +6500,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DiagnosisRole": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:DiagnosisType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6508,15 +6508,15 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DiagnosticReportCodes": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/lipidprofile",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
         },
         "urn:fhir:binding:DiagnosticReportStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
         },
         "urn:fhir:binding:DiagnosticServiceSection": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
         },
         "urn:fhir:binding:DICOMMediaType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6531,8 +6531,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/ElementDefinition",
         },
         "urn:fhir:binding:DocumentC80Class": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-adi-documentreference",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DocumentReference",
         },
         "urn:fhir:binding:DocumentC80FacilityType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6568,7 +6568,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:DocumentReferenceStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+            canonical: "http://hl7.org/fhir/StructureDefinition/DocumentManifest",
         },
         "urn:fhir:binding:DocumentRelationshipType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6611,24 +6611,24 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Questionnaire",
         },
         "urn:fhir:binding:EncounterClass": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterLocationStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterReason": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterServiceType": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:EncounterType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6740,7 +6740,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:FamilialRelationship": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/familymemberhistory-genetic",
+            canonical: "http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory",
         },
         "urn:fhir:binding:FamilyHistoryAbsentReason": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6788,7 +6788,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:FHIRTypes": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/OperationDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/GraphDefinition",
         },
         "urn:fhir:binding:FHIRVersion": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -6796,7 +6796,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:FilterOperator": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/ValueSet",
+            canonical: "http://hl7.org/fhir/StructureDefinition/CodeSystem",
         },
         "urn:fhir:binding:FlagCategory": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7016,11 +7016,11 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:Jurisdiction": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EventDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:Language": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/ValueSet",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Attachment",
         },
         "urn:fhir:binding:Laterality": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7032,7 +7032,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:LibraryType": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/modelinfolibrary",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Library",
         },
         "urn:fhir:binding:LinkageType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7071,8 +7071,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Location",
         },
         "urn:fhir:binding:LocationStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Location",
         },
         "urn:fhir:binding:LocationType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7183,8 +7183,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
         },
         "urn:fhir:binding:MedicationDispenseStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationdispense",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
         },
         "urn:fhir:binding:MedicationDispenseType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7192,15 +7192,15 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:MedicationForm": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationKnowledge",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Medication",
         },
         "urn:fhir:binding:MedicationFormalRepresentation": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationKnowledge",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Medication",
         },
         "urn:fhir:binding:MedicationIntendedSubstitutionReason": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
         },
         "urn:fhir:binding:MedicationIntendedSubstitutionType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7219,8 +7219,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
         },
         "urn:fhir:binding:MedicationRequestCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
         },
         "urn:fhir:binding:MedicationRequestCourseOfTherapy": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7296,7 +7296,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:MimeType": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Binary",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Attachment",
         },
         "urn:fhir:binding:MissingReason": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7304,7 +7304,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:Modifiers": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Claim",
         },
         "urn:fhir:binding:NameUse": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7343,8 +7343,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
         },
         "urn:fhir:binding:ObservationCode": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-average-blood-pressure",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:ObservationDataType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7371,16 +7371,16 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:ObservationStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-average-blood-pressure",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:ObservationUnit": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/ObservationDefinition",
         },
         "urn:fhir:binding:ObservationValueAbsentReason": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-average-blood-pressure",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Observation",
         },
         "urn:fhir:binding:OperationalStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7435,8 +7435,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/AppointmentResponse",
         },
         "urn:fhir:binding:ParticipantType": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Appointment",
         },
         "urn:fhir:binding:ParticipationStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7444,7 +7444,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:PatientDiet": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:PatientRelationshipType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7476,7 +7476,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:PhysicalType": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Location",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Encounter",
         },
         "urn:fhir:binding:PlanDefinitionType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7552,7 +7552,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ProcessPriority": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Claim",
         },
         "urn:fhir:binding:Program": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7608,7 +7608,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:PublicationStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EventDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:PurposeOfUse": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7640,7 +7640,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:QuantityComparator": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/SimpleQuantity",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Quantity",
         },
         "urn:fhir:binding:QuestionnaireConcept": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7655,8 +7655,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/Questionnaire",
         },
         "urn:fhir:binding:QuestionnaireResponseStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
         },
         "urn:fhir:binding:ReAdmissionType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7696,7 +7696,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:RemittanceOutcome": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/EnrollmentResponse",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ClaimResponse",
         },
         "urn:fhir:binding:repositoryType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7708,7 +7708,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:RequestPriority": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
         },
         "urn:fhir:binding:RequestStatus": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7780,7 +7780,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:RouteOfAdministration": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Dosage",
+            canonical: "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance",
         },
         "urn:fhir:binding:Safety": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7788,7 +7788,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:SearchComparator": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/SubscriptionTopic",
+            canonical: "http://hl7.org/fhir/StructureDefinition/SearchParameter",
         },
         "urn:fhir:binding:SearchEntryMode": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7796,7 +7796,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:SearchModifierCode": {
             package: "hl7.fhir.r5.core#5.0.0",
-            canonical: "http://hl7.org/fhir/StructureDefinition/SubscriptionTopic",
+            canonical: "http://hl7.org/fhir/StructureDefinition/SearchParameter",
         },
         "urn:fhir:binding:SearchParamType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7840,23 +7840,23 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:ServiceProduct": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest",
+            canonical: "http://hl7.org/fhir/StructureDefinition/Claim",
         },
         "urn:fhir:binding:ServiceProvisionConditions": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/HealthcareService",
         },
         "urn:fhir:binding:ServiceRequestCategory": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:ServiceRequestCode": {
             package: "hl7.fhir.r4.core#4.0.1",
             canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:ServiceRequestIntent": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:ServiceRequestLocation": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7875,12 +7875,12 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:ServiceRequestStatus": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-servicerequest",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
         },
         "urn:fhir:binding:Sex": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/familymemberhistory-genetic",
+            canonical: "http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory",
         },
         "urn:fhir:binding:SignatureType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -7943,8 +7943,8 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
             canonical: "http://hl7.org/fhir/StructureDefinition/VerificationResult",
         },
         "urn:fhir:binding:Status": {
-            package: "hl7.fhir.us.core#8.0.1",
-            canonical: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+            package: "hl7.fhir.r4.core#4.0.1",
+            canonical: "http://hl7.org/fhir/StructureDefinition/vitalsigns",
         },
         "urn:fhir:binding:strandType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -8012,7 +8012,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:SubstanceCode": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/Substance",
+            canonical: "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance",
         },
         "urn:fhir:binding:SupplementType": {
             package: "hl7.fhir.r4.core#4.0.1",
@@ -8196,7 +8196,7 @@ Add to `.typeSchema({ resolveCollisions: { ... } })` to resolve remaining collis
         },
         "urn:fhir:binding:VitalSigns": {
             package: "hl7.fhir.r4.core#4.0.1",
-            canonical: "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+            canonical: "http://hl7.org/fhir/StructureDefinition/bmi",
         },
         "urn:fhir:binding:XPathUsageType": {
             package: "hl7.fhir.r4.core#4.0.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
     "smol-toml": ">=1.6.1",
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.7",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"
   }

--- a/src/api/writer-generator/introspection.ts
+++ b/src/api/writer-generator/introspection.ts
@@ -113,12 +113,17 @@ export class IntrospectionWriter extends FileSystemWriter<IntrospectionWriterOpt
             );
         }
 
+        // Dump only schemas that survived IR transformations (e.g. tree shaking),
+        // mirroring the typeSchemas output.
+        const indexUrls = new Set<string>(tsIndex.schemas.map((ts) => ts.identifier.url));
+
         if (this.opts.fhirSchemas && tsIndex.register) {
             const outputPath = this.opts.fhirSchemas;
             const allFs = tsIndex.register.allFs();
             // Deduplicate FHIR schemas by URL (same schema can appear from different packages)
             const seenUrls = new Set<string>();
             const fhirSchemas = allFs.filter((fs) => {
+                if (!indexUrls.has(fs.url)) return false;
                 if (seenUrls.has(fs.url)) return false;
                 seenUrls.add(fs.url);
                 return true;
@@ -142,6 +147,7 @@ export class IntrospectionWriter extends FileSystemWriter<IntrospectionWriterOpt
             // Deduplicate SDs by URL (same SD can appear multiple times from different packages)
             const seenUrls = new Set<string>();
             const structureDefinitions = allSd.filter((sd) => {
+                if (!indexUrls.has(sd.url)) return false;
                 if (seenUrls.has(sd.url)) return false;
                 seenUrls.add(sd.url);
                 return true;

--- a/src/typeschema/collision-order.ts
+++ b/src/typeschema/collision-order.ts
@@ -1,0 +1,31 @@
+type CollisionSource = {
+    sourceCanonical: string;
+    sourcePackage: string;
+};
+
+type CollisionVariant = {
+    schemaHash: string;
+    sources: readonly CollisionSource[];
+};
+
+const compareStrings = (left: string, right: string): number => {
+    if (left < right) return -1;
+    if (left > right) return 1;
+    return 0;
+};
+
+export const compareCollisionSources = (left: CollisionSource, right: CollisionSource): number =>
+    compareStrings(left.sourcePackage, right.sourcePackage) ||
+    compareStrings(left.sourceCanonical, right.sourceCanonical);
+
+const collisionSourcesKey = (sources: readonly CollisionSource[]): string =>
+    JSON.stringify(
+        [...sources]
+            .sort(compareCollisionSources)
+            .map(({ sourcePackage, sourceCanonical }) => [sourcePackage, sourceCanonical]),
+    );
+
+export const compareCollisionVariants = (left: CollisionVariant, right: CollisionVariant): number =>
+    right.sources.length - left.sources.length ||
+    compareStrings(collisionSourcesKey(left.sources), collisionSourcesKey(right.sources)) ||
+    compareStrings(left.schemaHash, right.schemaHash);

--- a/src/typeschema/index.ts
+++ b/src/typeschema/index.ts
@@ -11,6 +11,7 @@
  */
 
 import type { CodegenLog } from "@root/utils/log";
+import { compareCollisionSources, compareCollisionVariants } from "./collision-order";
 import { transformFhirSchema, transformValueSet } from "./core/transformer";
 import type { ResolveCollisionsConf, TypeSchemaCollisions } from "./ir/types";
 import type { Register } from "./register";
@@ -54,7 +55,13 @@ const deduplicateSchemas = (
     const collisions: TypeSchemaCollisions = {};
 
     for (const versions of Object.values(groups)) {
-        const sorted = Object.values(versions).sort((a, b) => b.sources.length - a.sources.length);
+        const sorted = Object.entries(versions)
+            .map(([schemaHash, version]) => ({
+                ...version,
+                schemaHash,
+                sources: [...version.sources].sort(compareCollisionSources),
+            }))
+            .sort(compareCollisionVariants);
         const best = sorted[0];
         if (!best) continue;
 

--- a/src/typeschema/ir/report.ts
+++ b/src/typeschema/ir/report.ts
@@ -1,5 +1,6 @@
 import type { CanonicalUrl, PkgName } from "@root/typeschema/types";
-import { extractNameFromCanonical } from "@root/typeschema/types";
+import { extractNameFromCanonical, hashSchema } from "@root/typeschema/types";
+import { compareCollisionSources, compareCollisionVariants } from "../collision-order";
 import type {
     CollisionResolution,
     IrReport,
@@ -68,12 +69,19 @@ type VersionGroup = { entries: CollisionEntry[]; mark: VersionMark };
 const groupCollisionVersions = (entries: CollisionEntry[], resolution?: CollisionResolution): VersionGroup[] => {
     const uniqueSchemas = new Map<string, CollisionEntry[]>();
     for (const entry of entries) {
-        const key = JSON.stringify(entry.typeSchema);
+        const key = hashSchema(entry.typeSchema);
         if (!uniqueSchemas.has(key)) uniqueSchemas.set(key, []);
         uniqueSchemas.get(key)?.push(entry);
     }
 
-    const sorted = [...uniqueSchemas.values()].sort((a, b) => b.length - a.length);
+    const sorted = [...uniqueSchemas.entries()]
+        .map(([schemaHash, group]) => ({
+            entries: [...group].sort(compareCollisionSources),
+            schemaHash,
+            sources: group,
+        }))
+        .sort(compareCollisionVariants)
+        .map((group) => group.entries);
     const markVersion = (group: CollisionEntry[], i: number): VersionMark => {
         if (resolution)
             return group.some(

--- a/src/typeschema/register.ts
+++ b/src/typeschema/register.ts
@@ -300,8 +300,8 @@ export const registerFromManager = async (
                             if (!sd.package_name) {
                                 return {
                                     ...sd,
-                                    package_name: pkgIndex.pkg.name,
-                                    package_version: pkgIndex.pkg.version,
+                                    package_name: r.pkg.name,
+                                    package_version: r.pkg.version,
                                 };
                             }
                             return sd;

--- a/test/unit/typeschema/collision-order.test.ts
+++ b/test/unit/typeschema/collision-order.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { compareCollisionVariants } from "@root/typeschema/collision-order";
+
+describe("collision ordering", () => {
+    const variants = [
+        {
+            id: "more-sources",
+            schemaHash: "c",
+            sources: [
+                { sourcePackage: "pkg#1", sourceCanonical: "http://example.org/z" },
+                { sourcePackage: "pkg#1", sourceCanonical: "http://example.org/y" },
+            ],
+        },
+        {
+            id: "source-tie-break",
+            schemaHash: "b",
+            sources: [{ sourcePackage: "pkg#1", sourceCanonical: "http://example.org/a" }],
+        },
+        {
+            id: "hash-tie-break",
+            schemaHash: "a",
+            sources: [{ sourcePackage: "pkg#1", sourceCanonical: "http://example.org/a" }],
+        },
+    ];
+
+    it("orders variants independently of discovery order", () => {
+        const forward = [...variants].sort(compareCollisionVariants).map((variant) => variant.id);
+        const reversed = [...variants]
+            .reverse()
+            .sort(compareCollisionVariants)
+            .map((variant) => variant.id);
+
+        expect(forward).toEqual(["more-sources", "hash-tie-break", "source-tie-break"]);
+        expect(reversed).toEqual(forward);
+    });
+});


### PR DESCRIPTION
## Introspection fixes

- \`introspection({ fhirSchemas, structureDefinitions })\` now dumps only schemas present in the (tree-shaken) TypeSchema index, mirroring the existing \`typeSchemas\` behavior. Previously both options dumped the entire register.
- \`allSd()\` now stamps the fallback \`package_name\`/\`package_version\` from the resolution's source package instead of the containing package index, so StructureDefinitions are attributed to the package that actually declares them.

Both problems surfaced when generating a tree-shaken profile from a multi-package canonical-manager input (\`kbv.basis@1.9.0\`, single profile):

Before:

```
introspection (5535 files, 2967 kloc):
  fhir-schemas/...                          2579 files across 11 packages
  structure-definitions/kbv.basis/          2579 files  <- every SD, incl. R4 core, attributed to kbv.basis
```

After:

```
introspection (499 files, 56 kloc):
  fhir-schemas/hl7.fhir.r4.core/            60 files
  fhir-schemas/kbv.basis/                   1 file
  structure-definitions/hl7.fhir.r4.core/   62 files
  structure-definitions/de.basisprofil.r4/  1 file
  structure-definitions/hl7.fhir.uv.extensions.r4/ 1 file
  structure-definitions/kbv.basis/          2 files
```

## CI fixes

- Cherry-picked the bun audit fix from #198 (closed in favor of this PR): bump \`brace-expansion\` override \`>=5.0.6\` → \`>=5.0.7\` for GHSA-3jxr-9vmj-r5cp (high, DoS) — fixes the \`security\` job. Internal ref: #1634.
- Cherry-picked \`fix(typeschema): stabilize collision ordering\` from #196 — fixes platform-dependent collision auto-selection drift that failed the US Core example jobs; regenerating both examples now reproduces the committed output byte-for-byte.