### PR TITLE
Chore: fix bun audit brace-expansion advisory (#1634)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.7",
     "esbuild": ">=0.28.1",
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
@@ -281,7 +281,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
     "smol-toml": ">=1.6.1",
-    "brace-expansion": ">=5.0.6",
+    "brace-expansion": ">=5.0.7",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"
   }


### PR DESCRIPTION
- Bump `brace-expansion` override `>=5.0.6` → `>=5.0.7` (lock: 5.0.6 → 5.0.7) to fix GHSA-3jxr-9vmj-r5cp (high, DoS via exponential-time expansion of consecutive non-expanding `{}` groups), pulled in via `tsup › sucrase › glob › minimatch`.
- `bun audit` is clean after the bump; typecheck, lint, tests, and `bun run build` pass.