### PR TITLE
TypeSchema: resolve choice variants monotonically across the profile hierarchy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ VERSION = $(shell cat package.json | grep version | sed -E 's/ *"version": "//' 
 	test test-multi-package \
 	prepare-aidbox-runme test-all-example-generation test-other-example-generation \
 	test-on-the-fly-example test-on-the-fly-norge-r4 test-on-the-fly-kbv-r4 test-on-the-fly-ccda \
+	test-on-the-fly-kbv-condition-diagnosis \
 	test-typescript-r4-us-core-example test-typescript-custom-packages-example \
 	test-mustache-java-r4-example \
 	test-csharp-sdk generate-python-r4-us-core-sdk generate-python-r4-sdk \
@@ -62,7 +63,7 @@ test-all-example-generation: test-other-example-generation
 
 test-other-example-generation: test-on-the-fly-example
 
-test-on-the-fly-example: test-on-the-fly-norge-r4 test-on-the-fly-kbv-r4 test-on-the-fly-ccda
+test-on-the-fly-example: test-on-the-fly-norge-r4 test-on-the-fly-kbv-r4 test-on-the-fly-kbv-condition-diagnosis test-on-the-fly-ccda
 
 test-on-the-fly-norge-r4: typecheck
 	bun run examples/on-the-fly/norge-r4/generate.ts
@@ -73,6 +74,10 @@ test-on-the-fly-kbv-r4: typecheck
 	bun run examples/on-the-fly/kbv-r4/generate.ts
 	$(TYPECHECK) --project examples/on-the-fly/kbv-r4/tsconfig.json
 	bun test ./examples/on-the-fly/kbv-r4/
+
+test-on-the-fly-kbv-condition-diagnosis: typecheck
+	bun run examples/on-the-fly/kbv-condition-diagnosis/generate.ts
+	$(TYPECHECK) --project examples/on-the-fly/kbv-condition-diagnosis/tsconfig.json
 
 test-on-the-fly-ccda: typecheck
 	bun run examples/on-the-fly/ccda/generate.ts

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@atomic-ehr/codegen",
       "dependencies": {
         "@atomic-ehr/fhir-canonical-manager": "0.0.24",
-        "@atomic-ehr/fhirschema": "0.0.13",
+        "@atomic-ehr/fhirschema": "0.0.14",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
         "yaml": "^2.9.0",
@@ -35,7 +35,7 @@
   "packages": {
     "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.24", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-3h+uGf3qqxNX2oClVx+Fz1NZ2Jm2h2dXKrbhA77gURmX5TUYYQKxdTh58a7N/tteLLsig5fW8q41wfeUqy7GdQ=="],
 
-    "@atomic-ehr/fhirschema": ["@atomic-ehr/fhirschema@0.0.13", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-4v5yLdvfeeXuXM3Y2AvNbukC5qiKa/Kts7kwe+8Mf0GqhvJwxjl2iHX4a/AZChFD7nkL02R5iEIpKKE3c7BFOg=="],
+    "@atomic-ehr/fhirschema": ["@atomic-ehr/fhirschema@0.0.14", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-RqSQI0y82d+2+Uti8OyurIA+DxyUT9P6GZ9b4HXbCsgurpBvf752ZckuISVOuhabqXWZpBjZfiRbrYNPZYuxKw=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
 

--- a/examples/on-the-fly/kbv-condition-diagnosis/generate.ts
+++ b/examples/on-the-fly/kbv-condition-diagnosis/generate.ts
@@ -1,0 +1,46 @@
+// Run this script using Bun CLI with:
+// bun run examples/on-the-fly/kbv-condition-diagnosis/generate.ts
+
+import { APIBuilder, prettyReport } from "../../../src/api/builder";
+
+// Generates TypeScript types for the KBV_PR_Base_Condition_Diagnosis profile
+// (kbv.basis@1.9.0) together with full introspection output: TypeSchemas,
+// FHIR schemas, and source StructureDefinitions. The profile type-slices the
+// Condition.onset[x] and abatement[x] choice elements with open slicing rules.
+if (require.main === module) {
+    console.log("Generating KBV Condition Diagnosis types...");
+
+    const builder = new APIBuilder({
+        registry: "https://packages.simplifier.net",
+        ignorePackageIndex: true,
+    })
+        .fromPackage("kbv.basis", "1.9.0")
+        .throwException()
+        .typescript({
+            withDebugComment: false,
+            generateProfile: true,
+            openResourceTypeSet: false,
+        })
+        .typeSchema({
+            treeShake: {
+                "kbv.basis": {
+                    "https://fhir.kbv.de/StructureDefinition/KBV_PR_Base_Condition_Diagnosis": {},
+                    // Referenced as a Condition.subject target; included so the
+                    // reference type resolves to the profile's base resource.
+                    "https://fhir.kbv.de/StructureDefinition/KBV_PR_Base_Patient": {},
+                },
+            },
+        })
+        .introspection({
+            typeSchemas: { target: "type-schemas", profileSnapshots: true },
+            fhirSchemas: "fhir-schemas",
+            structureDefinitions: "structure-definitions",
+            typeTree: "type-tree.yaml",
+        })
+        .outputTo("./examples/on-the-fly/kbv-condition-diagnosis/fhir-types")
+        .cleanOutput(true);
+
+    const report = await builder.generate();
+    console.log(prettyReport(report));
+    if (!report.success) process.exit(1);
+}

--- a/examples/on-the-fly/kbv-condition-diagnosis/tsconfig.json
+++ b/examples/on-the-fly/kbv-condition-diagnosis/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["."]
+}

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_bodyweight.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_bodyweight.ts
@@ -214,6 +214,7 @@ export class observation_bodyweightProfile {
                 ...validateChoiceProhibited(res, profileName, ["effectiveTiming","effectiveInstant"]),
                 ...validateReference(res, profileName, "hasMember", ["MolecularSequence","QuestionnaireResponse","Observation"]),
                 ...validateReference(res, profileName, "derivedFrom", ["DocumentReference","ImagingStudy","Media","MolecularSequence","QuestionnaireResponse","Observation"]),
+                ...validateChoiceProhibited(res, profileName, ["valueCodeableConcept","valueString","valueBoolean","valueInteger","valueRange","valueRatio","valueSampledData","valueTime","valueDateTime","valuePeriod"]),
             ],
             warnings: [
                 ...validateEnum(res, profileName, "category", ["social-history","vital-signs","imaging","laboratory","procedure","survey","exam","therapy","activity"]),

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_bp.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_bp.ts
@@ -299,6 +299,7 @@ export class observation_bpProfile {
                 ...validateSliceFields(res, profileName, "component", {"code":{"coding":[{"code":"8480-6","system":"http://loinc.org"}]}}, "SystolicBP", ["valueQuantity"]),
                 ...validateSliceCardinality(res, profileName, "component", {"code":{"coding":[{"code":"8462-4","system":"http://loinc.org"}]}}, "DiastolicBP", 1, 1),
                 ...validateSliceFields(res, profileName, "component", {"code":{"coding":[{"code":"8462-4","system":"http://loinc.org"}]}}, "DiastolicBP", ["valueQuantity"]),
+                ...validateChoiceProhibited(res, profileName, ["valueCodeableConcept","valueString","valueBoolean","valueInteger","valueRange","valueRatio","valueSampledData","valueTime","valueDateTime","valuePeriod"]),
             ],
             warnings: [
                 ...validateEnum(res, profileName, "category", ["social-history","vital-signs","imaging","laboratory","procedure","survey","exam","therapy","activity"]),

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/atomic-ehr/codegen#readme",
   "dependencies": {
     "@atomic-ehr/fhir-canonical-manager": "0.0.24",
-    "@atomic-ehr/fhirschema": "0.0.13",
+    "@atomic-ehr/fhirschema": "0.0.14",
     "mustache": "^4.2.0",
     "picocolors": "^1.1.1",
     "yaml": "^2.9.0",

--- a/src/typeschema/types.ts
+++ b/src/typeschema/types.ts
@@ -293,7 +293,7 @@ export const isSnapshotProfileTypeSchema = (s: TypeSchemaGuardInput): s is Snaps
 
 export interface FieldSlicing {
     discriminator?: FS.FHIRSchemaDiscriminator[];
-    rules?: string;
+    rules?: FS.SlicingRules;
     ordered?: boolean;
     slices?: Record<string, FieldSlice>;
 }

--- a/src/typeschema/utils.ts
+++ b/src/typeschema/utils.ts
@@ -8,6 +8,7 @@ import {
     type BindingIdentifier,
     type BindingTypeSchema,
     type CanonicalUrl,
+    type ChoiceFieldDeclaration,
     type ChoiceFieldInstance,
     type ComplexTypeIdentifier,
     type ComplexTypeTypeSchema,
@@ -366,6 +367,89 @@ export type TypeSchemaIndex = {
 
 type EntityTree = Record<PkgName, Record<TypeIdentifier["kind"], Record<CanonicalUrl, object>>>;
 
+const choiceInstances = (fields: Record<string, Field>, declName: string): [string, ChoiceFieldInstance][] =>
+    Object.entries(fields).filter(
+        (e): e is [string, ChoiceFieldInstance] => isChoiceInstanceField(e[1]) && e[1].choiceOf === declName,
+    );
+
+/** Every variant name known for a choice group: the base declaration's choices,
+ *  the (merged) declaration's choices, and any declared instances. */
+const choiceUniverse = (
+    fields: Record<string, Field>,
+    baseFields: Record<string, Field>,
+    declName: string,
+    declField: ChoiceFieldDeclaration,
+): string[] => {
+    const baseDecl = baseFields[declName];
+    const baseChoices = isChoiceDeclarationField(baseDecl) ? baseDecl.choices : [];
+    return [
+        ...new Set([...baseChoices, ...declField.choices, ...choiceInstances(fields, declName).map(([name]) => name)]),
+    ];
+};
+
+/** Variant names a schema positively declares for a choice group: the restated
+ *  declaration's choices plus non-excluded instances. */
+const declaredChoiceVariants = (fields: Record<string, Field>, declName: string): string[] => {
+    const declaration = fields[declName];
+    const fromDeclaration = isChoiceDeclarationField(declaration) && !declaration.excluded ? declaration.choices : [];
+    const fromInstances = choiceInstances(fields, declName)
+        .filter(([, field]) => !field.excluded)
+        .map(([name]) => name);
+    return [...new Set([...fromDeclaration, ...fromInstances])];
+};
+
+/** Fold every profile's choice constraints over the base declaration's permitted set,
+ *  base-to-leaf, warning when a profile declares variants an ancestor already prohibited. */
+const resolvePermittedChoiceVariants = (
+    universe: string[],
+    baseDeclaration: Field | undefined,
+    constraintSchemas: TypeSchema[],
+    declName: string,
+    logger?: CodegenLog,
+): Set<string> => {
+    let permitted = new Set(isChoiceDeclarationField(baseDeclaration) ? baseDeclaration.choices : universe);
+    for (const schema of constraintSchemas.slice().reverse()) {
+        const fields = (schema as SpecializationTypeSchema).fields;
+        if (!fields) continue;
+        const reintroduced = declaredChoiceVariants(fields, declName).filter((name) => !permitted.has(name));
+        if (reintroduced.length > 0)
+            logger?.dryWarn(
+                "#nonMonotonicChoice",
+                `Profile '${schema.identifier.name}' declares choice variant(s) ${reintroduced.join(", ")} of '${declName}' that an ancestor prohibits; they stay prohibited`,
+            );
+        permitted = applyChoiceConstraints(permitted, fields, declName);
+    }
+    return permitted;
+};
+
+/** Apply one profile schema's choice constraints to the permitted variant set.
+ *  A restated declaration narrows to its choices; instances declared without the
+ *  declaration narrow to the instance names; an excluded instance removes its
+ *  variant. Everything intersects, so resolution stays monotonic base-to-leaf. */
+const applyChoiceConstraints = (
+    permitted: Set<string>,
+    fields: Record<string, Field>,
+    declName: string,
+): Set<string> => {
+    const result = new Set(permitted);
+    const instances = choiceInstances(fields, declName);
+    for (const [name, field] of instances) {
+        if (field.excluded) result.delete(name);
+    }
+
+    const declaration = fields[declName];
+    if (isChoiceDeclarationField(declaration)) {
+        if (declaration.excluded) return new Set();
+        const declared = new Set(declaration.choices);
+        return new Set([...result].filter((name) => declared.has(name)));
+    }
+
+    const declared = instances.filter(([, field]) => !field.excluded).map(([name]) => name);
+    if (declared.length === 0) return result;
+    const declaredSet = new Set(declared);
+    return new Set([...result].filter((name) => declaredSet.has(name)));
+};
+
 export const mkTypeSchemaIndex = (
     schemas: TypeSchema[],
     {
@@ -497,52 +581,41 @@ export const mkTypeSchemaIndex = (
         return findLastSpecialization(resolved).identifier;
     };
 
-    /** Narrow choice declarations by finding the most derived schema that constrains each choice group.
-     *  When a child profile declares only specific choice instances without re-declaring the declaration,
-     *  restrict the declaration's choices array to only the allowed instances. */
+    /** Resolve the permitted choice variants monotonically through the profile hierarchy.
+     *  Each profile's constraints (restated declaration, declared instances, exclusions)
+     *  intersect with the inherited permitted set, so a child profile can never
+     *  reintroduce a variant an ancestor prohibited. Declarations the chain constrains
+     *  only via instances are materialized from the base when something is prohibited. */
     const narrowMergedChoiceDeclarations = (
         mergedFields: Record<string, Field>,
         constraintSchemas: TypeSchema[],
         baseFields: Record<string, Field> = {},
     ): Record<string, Field> => {
         const result = { ...mergedFields };
-        for (const [declName, declField] of Object.entries(result)) {
-            if (!isChoiceDeclarationField(declField) || declField.excluded) continue;
+        const declNames = new Set([...Object.keys(result), ...Object.keys(baseFields)]);
 
-            for (const cSchema of constraintSchemas) {
-                const sFields = (cSchema as SpecializationTypeSchema).fields;
-                if (!sFields) continue;
-                if (sFields[declName] && isChoiceDeclarationField(sFields[declName])) continue;
-
-                const instancesInSchema = Object.entries(sFields)
-                    .filter(([_, f]) => isChoiceInstanceField(f) && (f as ChoiceFieldInstance).choiceOf === declName)
-                    .map(([name]) => name);
-                if (instancesInSchema.length === 0) continue;
-
-                const allowed = new Set(instancesInSchema);
-                result[declName] = { ...declField, choices: declField.choices.filter((c) => allowed.has(c)) };
-                break;
-            }
-        }
-
-        // Compute prohibited for all choice declarations. Variants declared on
-        // the base specialization count even when the profile does not restate
-        // them — omitting a variant from a narrowed choice prohibits it.
-        for (const [declName, declField] of Object.entries(result)) {
+        for (const declName of declNames) {
+            const declField = result[declName] ?? baseFields[declName];
             if (!isChoiceDeclarationField(declField)) continue;
-            const permitted = new Set(declField.excluded ? [] : declField.choices);
-            const baseDecl = baseFields[declName];
-            const baseChoices = isChoiceDeclarationField(baseDecl) ? baseDecl.choices : [];
-            const mergedInstances = Object.entries(result)
-                .filter(
-                    (e): e is [string, ChoiceFieldInstance] =>
-                        isChoiceInstanceField(e[1]) && e[1].choiceOf === declName,
-                )
-                .map(([name]) => name);
-            const prohibited = [...new Set([...baseChoices, ...mergedInstances])].filter(
-                (name) => !permitted.has(name),
+            const restated = result[declName] !== undefined;
+            if (!restated && choiceInstances(result, declName).length === 0) continue;
+
+            const universe = choiceUniverse(result, baseFields, declName, declField);
+            const permitted = resolvePermittedChoiceVariants(
+                universe,
+                baseFields[declName],
+                constraintSchemas,
+                declName,
+                logger,
             );
-            if (prohibited.length > 0) result[declName] = { ...declField, prohibited };
+
+            const prohibited = universe.filter((name) => !permitted.has(name));
+            if (!restated && prohibited.length === 0) continue;
+            result[declName] = {
+                ...declField,
+                choices: universe.filter((name) => permitted.has(name)),
+                ...(prohibited.length > 0 ? { prohibited } : {}),
+            };
         }
 
         return result;

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -19,7 +19,8 @@ export type CodegenTag =
     | "#duplicateSchema"
     | "#duplicateCanonical"
     | "#resolveBase"
-    | "#resolveCollisionMiss";
+    | "#resolveCollisionMiss"
+    | "#nonMonotonicChoice";
 
 export type CodegenLog = Log<CodegenTag>;
 export type CodegenLogManager = LogManager<CodegenTag>;

--- a/test/api/write-generator/__snapshots__/introspection.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/introspection.test.ts.snap
@@ -3120,6 +3120,26 @@ exports[`IntrospectionWriter - flat profile output Check bodyweight flat profile
       "excluded": false,
       "array": false,
       "choiceOf": "value"
+    },
+    "value": {
+      "required": false,
+      "excluded": false,
+      "array": false,
+      "choices": [
+        "valueQuantity"
+      ],
+      "prohibited": [
+        "valueCodeableConcept",
+        "valueString",
+        "valueBoolean",
+        "valueInteger",
+        "valueRange",
+        "valueRatio",
+        "valueSampledData",
+        "valueTime",
+        "valueDateTime",
+        "valuePeriod"
+      ]
     }
   },
   "dependencies": [

--- a/test/api/write-generator/__snapshots__/typescript.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/typescript.test.ts.snap
@@ -717,6 +717,7 @@ export class observation_bodyweightProfile {
                 ...validateChoiceProhibited(res, profileName, ["effectiveTiming","effectiveInstant"]),
                 ...validateReference(res, profileName, "hasMember", ["MolecularSequence","QuestionnaireResponse","Observation"]),
                 ...validateReference(res, profileName, "derivedFrom", ["DocumentReference","ImagingStudy","Media","MolecularSequence","QuestionnaireResponse","Observation"]),
+                ...validateChoiceProhibited(res, profileName, ["valueCodeableConcept","valueString","valueBoolean","valueInteger","valueRange","valueRatio","valueSampledData","valueTime","valueDateTime","valuePeriod"]),
             ],
             warnings: [
                 ...validateEnum(res, profileName, "category", ["social-history","vital-signs","imaging","laboratory","procedure","survey","exam","therapy","activity"]),
@@ -1034,6 +1035,7 @@ export class observation_bpProfile {
                 ...validateSliceFields(res, profileName, "component", {"code":{"coding":[{"code":"8480-6","system":"http://loinc.org"}]}}, "SystolicBP", ["valueQuantity"]),
                 ...validateSliceCardinality(res, profileName, "component", {"code":{"coding":[{"code":"8462-4","system":"http://loinc.org"}]}}, "DiastolicBP", 1, 1),
                 ...validateSliceFields(res, profileName, "component", {"code":{"coding":[{"code":"8462-4","system":"http://loinc.org"}]}}, "DiastolicBP", ["valueQuantity"]),
+                ...validateChoiceProhibited(res, profileName, ["valueCodeableConcept","valueString","valueBoolean","valueInteger","valueRange","valueRatio","valueSampledData","valueTime","valueDateTime","valuePeriod"]),
             ],
             warnings: [
                 ...validateEnum(res, profileName, "category", ["social-history","vital-signs","imaging","laboratory","procedure","survey","exam","therapy","activity"]),

--- a/test/unit/typeschema/utils.test.ts
+++ b/test/unit/typeschema/utils.test.ts
@@ -8,6 +8,7 @@ import type {
     TypeIdentifier,
 } from "@typeschema/types";
 import { mkTypeSchemaIndex } from "@typeschema/utils";
+import { mkErrorLogger } from "@typeschema-test/utils";
 
 const stringType: TypeIdentifier = {
     name: "string" as Name,
@@ -57,7 +58,7 @@ const _rangeType: TypeIdentifier = {
     url: "http://example.org/StructureDefinition/Range" as CanonicalUrl,
 };
 
-const _ageType: TypeIdentifier = {
+const ageType: TypeIdentifier = {
     name: "Age" as Name,
     package: "test",
     kind: "complex-type",
@@ -815,64 +816,100 @@ describe("TypeSchema Index", () => {
     });
 
     describe("choice prohibited fields", () => {
+        const baseSchema: SpecializationTypeSchema = {
+            identifier: {
+                name: "Base" as Name,
+                package: "test",
+                kind: "resource",
+                version: "1.0.0",
+                url: "http://example.org/StructureDefinition/Base" as CanonicalUrl,
+            },
+            fields: {
+                onset: {
+                    choices: ["onsetDateTime", "onsetPeriod", "onsetRange", "onsetAge"],
+                },
+            },
+        };
+        const constraintSchema: ProfileTypeSchema = {
+            identifier: {
+                name: "Constraint" as Name,
+                package: "test",
+                kind: "profile",
+                version: "1.0.0",
+                url: "http://example.org/StructureDefinition/Constraint" as CanonicalUrl,
+            },
+            base: baseSchema.identifier,
+            fields: {
+                onset: {
+                    choices: ["onsetRange", "onsetAge"],
+                },
+            },
+        };
+        const emptyTransitSchema: ProfileTypeSchema = {
+            identifier: {
+                name: "EmptyTransitSchema" as Name,
+                package: "test",
+                kind: "profile",
+                version: "1.0.0",
+                url: "http://example.org/StructureDefinition/EmptyTransitSchema" as CanonicalUrl,
+            },
+            base: constraintSchema.identifier,
+        };
+        const leafSchema: ProfileTypeSchema = {
+            identifier: {
+                name: "LeafConstraint" as Name,
+                package: "test",
+                kind: "profile",
+                version: "1.0.0",
+                url: "http://example.org/StructureDefinition/LeafConstraint" as CanonicalUrl,
+            },
+            base: emptyTransitSchema.identifier,
+            fields: {
+                onset: {
+                    choices: ["onsetAge"],
+                },
+            },
+        };
+        const excludedFieldSchema: ProfileTypeSchema = {
+            identifier: {
+                name: "ExcludedFieldSchema" as Name,
+                package: "test",
+                kind: "profile",
+                version: "1.0.0",
+                url: "http://example.org/StructureDefinition/ExcludedFieldSchema" as CanonicalUrl,
+            },
+            base: baseSchema.identifier,
+            fields: {
+                onsetAge: {
+                    choiceOf: "onset",
+                    type: ageType,
+                    excluded: true,
+                },
+            },
+        };
+        const leaf2Schema: ProfileTypeSchema = {
+            identifier: {
+                name: "Leaf2Schema" as Name,
+                package: "test",
+                kind: "profile",
+                version: "1.0.0",
+                url: "http://example.org/StructureDefinition/Leaf2Schema" as CanonicalUrl,
+            },
+            base: excludedFieldSchema.identifier,
+            fields: {
+                onset: {
+                    choices: ["onsetRange", "onsetAge"],
+                },
+            },
+        };
+
+        const logger = mkErrorLogger();
+        const tsIndex = mkTypeSchemaIndex(
+            [baseSchema, constraintSchema, emptyTransitSchema, leafSchema, excludedFieldSchema, leaf2Schema],
+            { logger },
+        );
+
         it("keeps undeclared instances prohibited in a choice type", () => {
-            const baseSchema: SpecializationTypeSchema = {
-                identifier: {
-                    name: "Base" as Name,
-                    package: "test",
-                    kind: "resource",
-                    version: "1.0.0",
-                    url: "http://example.org/StructureDefinition/Base" as CanonicalUrl,
-                },
-                fields: {
-                    onset: {
-                        choices: ["onsetDateTime", "onsetPeriod", "onsetRange", "onsetAge"],
-                    },
-                },
-            };
-            const constraintSchema: ProfileTypeSchema = {
-                identifier: {
-                    name: "Constraint" as Name,
-                    package: "test",
-                    kind: "profile",
-                    version: "1.0.0",
-                    url: "http://example.org/StructureDefinition/Constraint" as CanonicalUrl,
-                },
-                base: baseSchema.identifier,
-                fields: {
-                    onset: {
-                        choices: ["onsetRange", "onsetAge"],
-                    },
-                },
-            };
-            const emptyTransitSchema: ProfileTypeSchema = {
-                identifier: {
-                    name: "EmptyTransitSchema" as Name,
-                    package: "test",
-                    kind: "profile",
-                    version: "1.0.0",
-                    url: "http://example.org/StructureDefinition/EmptyTransitSchema" as CanonicalUrl,
-                },
-                base: constraintSchema.identifier,
-            };
-            const leafSchema: ProfileTypeSchema = {
-                identifier: {
-                    name: "LeafConstraint" as Name,
-                    package: "test",
-                    kind: "profile",
-                    version: "1.0.0",
-                    url: "http://example.org/StructureDefinition/LeafConstraint" as CanonicalUrl,
-                },
-                base: emptyTransitSchema.identifier,
-                fields: {
-                    onset: {
-                        choices: ["onsetAge"],
-                    },
-                },
-            };
-
-            const tsIndex = mkTypeSchemaIndex([baseSchema, constraintSchema, emptyTransitSchema, leafSchema], {});
-
             const flatConstraintSchema = tsIndex.flatProfile(constraintSchema);
             expect(flatConstraintSchema.fields?.onset).toMatchObject({
                 choices: ["onsetRange", "onsetAge"],
@@ -890,6 +927,40 @@ describe("TypeSchema Index", () => {
                 choices: ["onsetAge"],
                 prohibited: ["onsetDateTime", "onsetPeriod", "onsetRange"],
             });
+
+            // Excluding an instance prohibits that variant; the declaration is
+            // materialized from the base even though the profile never restates it.
+            const flatExcludedFieldSchema = tsIndex.flatProfile(excludedFieldSchema);
+            expect(flatExcludedFieldSchema.fields?.onset).toMatchObject({
+                choices: ["onsetDateTime", "onsetPeriod", "onsetRange"],
+                prohibited: ["onsetAge"],
+            });
+        });
+
+        it("monotonic choice variants", () => {
+            // Monotonic: leaf2 restates onsetAge, but cannot reintroduce a
+            // variant its parent excluded.
+            const flatLeaf2Schema = tsIndex.flatProfile(leaf2Schema);
+            expect(flatLeaf2Schema.fields?.onset).toMatchObject({
+                choices: ["onsetRange"],
+                prohibited: ["onsetDateTime", "onsetPeriod", "onsetAge"],
+            });
+
+            // The reintroduction attempt is the only distinct warning — ordinary
+            // narrowing in the sibling profiles does not warn. (The buffer holds
+            // one entry from the eager snapshot build at index creation and one
+            // from the flatProfile call above; dryWarn dedupes only the output.)
+            const warnings = [
+                ...new Set(
+                    logger
+                        .buffer()
+                        .filter((e) => e.tag === "#nonMonotonicChoice")
+                        .map((e) => e.message),
+                ),
+            ];
+            expect(warnings).toHaveLength(1);
+            expect(warnings[0]).toContain("Leaf2Schema");
+            expect(warnings[0]).toContain("onsetAge");
         });
     });
 });


### PR DESCRIPTION
## Choice variant resolution

- Fold every profile's choice constraints (restated declaration, declared instances, excluded instances) over the base declaration's permitted set, base-to-leaf, so a child profile can never reintroduce a variant an ancestor prohibited.
- Materialize declarations constrained only via instances (e.g. exclusion-only profiles) from the base, with narrowed `choices` and the computed `prohibited` list.
- Report reintroduction attempts via the new `#nonMonotonicChoice` warning tag.
- Tests cover excluded variants, monotonic narrowing, and the non-monotonic warning.

## Supporting changes

- Bump `@atomic-ehr/fhirschema` to 0.0.14 — choice declarations' `choices` now derive from the explicit `ElementDefinition.type` ceiling, never from slice names; choice type slicing is collapsed with slicing metadata preserved.
- Tighten `FieldSlicing.rules` typing to `FS.SlicingRules`.
- Add an on-the-fly example generating `KBV_PR_Base_Condition_Diagnosis` from `kbv.basis@1.9.0` (open-sliced `onset[x]`/`abatement[x]`, see #196) with full introspection output, wired into the Makefile.

Profiles that genuinely restrict a choice now emit the full prohibited list in `validate()`, while open-sliced choice roots that restate nothing (KBV `onset[x]`) keep all base variants permitted and emit no checks:

```ts
// bodyweight validate() — before
...validateChoiceRequired(res, profileName, ["valueQuantity"]),

// after
...validateChoiceRequired(res, profileName, ["valueQuantity"]),
...validateChoiceProhibited(res, profileName, ["valueCodeableConcept","valueString","valueBoolean","valueInteger","valueRange","valueRatio","valueSampledData","valueTime","valueDateTime","valuePeriod"]),
```