### PR TITLE
TypeScript: preserve profile slice inputs and accessor names

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@atomic-ehr/fhir-canonical-manager": "0.0.24",
         "@atomic-ehr/fhirschema": "0.0.14",
-        "brace-expansion": "^5.0.8",
+        "brace-expansion": "^5.0.9",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
         "yaml": "^2.9.0",
@@ -26,7 +26,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "esbuild": ">=0.28.1",
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
@@ -282,7 +282,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@atomic-ehr/fhir-canonical-manager": "0.0.24",
     "@atomic-ehr/fhirschema": "0.0.14",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "mustache": "^4.2.0",
     "picocolors": "^1.1.1",
     "yaml": "^2.9.0",
@@ -69,7 +69,7 @@
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
     "smol-toml": ">=1.6.1",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"
   }

--- a/src/api/writer-generator/typescript/profile-slices.ts
+++ b/src/api/writer-generator/typescript/profile-slices.ts
@@ -26,8 +26,9 @@ export const sliceAccessorBaseName = (
     candidates: readonly string[],
     recommended: string,
     fieldNames: readonly string[],
+    reservedNames: ReadonlySet<string> = new Set(),
 ): string => {
-    const reserved = new Set(fieldNames.map((name) => uppercaseFirstLetter(name)));
+    const reserved = new Set([...fieldNames.map((name) => uppercaseFirstLetter(name)), ...reservedNames]);
     if (!reserved.has(recommended)) return recommended;
     return candidates.find((candidate) => !reserved.has(candidate)) ?? recommended;
 };
@@ -130,8 +131,9 @@ export type SliceDef = {
     max: number;
 };
 
-export const collectSliceDefs = (tsIndex: TypeSchemaIndex, snapshot: SnapshotProfileTypeSchema): SliceDef[] =>
-    Object.entries(snapshot.slicing ?? {}).flatMap(([fieldName, fieldSlicing]) => {
+export const collectSliceDefs = (tsIndex: TypeSchemaIndex, snapshot: SnapshotProfileTypeSchema): SliceDef[] => {
+    const reservedBaseNames = new Set<string>();
+    return Object.entries(snapshot.slicing ?? {}).flatMap(([fieldName, fieldSlicing]) => {
         const field = snapshot.fields[fieldName];
         if (!isNotChoiceDeclarationField(field) || !fieldSlicing.slices || !field.type) return [];
         const baseType = tsTypeFromIdentifier(field.type);
@@ -150,16 +152,19 @@ export const collectSliceDefs = (tsIndex: TypeSchemaIndex, snapshot: SnapshotPro
                 const constrainedChoice = cc && !isPrimitiveIdentifier(cc.variantType) ? cc : undefined;
                 const resourceType = isTypeDisc ? extractResourceTypeFromMatch(slice.match ?? {}) : undefined;
                 const typedBaseType = resourceType ? `${baseType}<${resourceType}>` : baseType;
+                const baseName = sliceAccessorBaseName(
+                    slice.nameCandidates.candidates,
+                    slice.nameCandidates.recommended,
+                    Object.keys(snapshot.fields),
+                    reservedBaseNames,
+                );
+                reservedBaseNames.add(baseName);
                 return {
                     fieldName,
                     baseType,
                     typedBaseType,
                     sliceName,
-                    baseName: sliceAccessorBaseName(
-                        slice.nameCandidates.candidates,
-                        slice.nameCandidates.recommended,
-                        Object.keys(snapshot.fields),
-                    ),
+                    baseName,
                     match: slice.match ?? {},
                     required,
                     excluded: slice.excluded ?? [],
@@ -170,6 +175,7 @@ export const collectSliceDefs = (tsIndex: TypeSchemaIndex, snapshot: SnapshotPro
                 };
             });
     });
+};
 
 export const generateSliceSetters = (w: TypeScript, sliceDefs: SliceDef[], snapshot: SnapshotProfileTypeSchema) => {
     const profileClassName = tsProfileClassName(snapshot);

--- a/src/api/writer-generator/typescript/profile-slices.ts
+++ b/src/api/writer-generator/typescript/profile-slices.ts
@@ -10,6 +10,7 @@ import {
     type TypeIdentifier,
 } from "@root/typeschema/types";
 import type { TypeSchemaIndex } from "@root/typeschema/utils";
+import { uppercaseFirstLetter } from "../utils";
 import {
     tsFieldName,
     tsProfileClassName,
@@ -20,6 +21,16 @@ import {
 } from "./name";
 import { tsGet, tsTypeFromIdentifier } from "./utils";
 import type { TypeScript } from "./writer";
+
+export const sliceAccessorBaseName = (
+    candidates: readonly string[],
+    recommended: string,
+    fieldNames: readonly string[],
+): string => {
+    const reserved = new Set(fieldNames.map((name) => uppercaseFirstLetter(name)));
+    if (!reserved.has(recommended)) return recommended;
+    return candidates.find((candidate) => !reserved.has(candidate)) ?? recommended;
+};
 
 /** Collect choice declaration field names from a base type schema */
 const collectChoiceBaseNames = (tsIndex: TypeSchemaIndex, typeId: TypeIdentifier): Set<string> => {
@@ -144,7 +155,11 @@ export const collectSliceDefs = (tsIndex: TypeSchemaIndex, snapshot: SnapshotPro
                     baseType,
                     typedBaseType,
                     sliceName,
-                    baseName: slice.nameCandidates.recommended,
+                    baseName: sliceAccessorBaseName(
+                        slice.nameCandidates.candidates,
+                        slice.nameCandidates.recommended,
+                        Object.keys(snapshot.fields),
+                    ),
                     match: slice.match ?? {},
                     required,
                     excluded: slice.excluded ?? [],

--- a/src/typeschema/core/field-builder.ts
+++ b/src/typeschema/core/field-builder.ts
@@ -397,7 +397,10 @@ export const mkField = (
         valueConstraint = { kind: "fixed", type: element.fixed.type, value: element.fixed.value };
     }
 
-    // Auto-populate valueConstraint for CodeableConcept fields with fixed coding slices.
+    // Auto-populate valueConstraint only when required coding slices fully fix
+    // each Coding. A discriminator-only match (for example a fixed system with
+    // a required user-supplied code) constrains the slice but does not fix the
+    // parent CodeableConcept value.
     // Uses rawElement because the resolved element snapshot has sub-elements stripped.
     const elemForCodingCheck = rawElement ?? element;
     if (!valueConstraint && elemForCodingCheck.elements?.coding?.slicing?.slices) {
@@ -411,7 +414,8 @@ export const mkField = (
                     s.min >= 1 &&
                     s.match &&
                     typeof s.match === "object" &&
-                    Object.keys(s.match as object).length > 0,
+                    typeof (s.match as FHIRCoding).system === "string" &&
+                    typeof (s.match as FHIRCoding).code === "string",
             );
         if (allRequired) {
             const codingValues = allSliceValues.flatMap((s) => (s.match ? [s.match as FHIRCoding] : []));

--- a/test/api/write-generator/typescript.test.ts
+++ b/test/api/write-generator/typescript.test.ts
@@ -133,7 +133,7 @@ describe("TypeScript profile fixed CodeableConcept semantics", async () => {
                                 slices: {
                                     InsuranceType: {
                                         min: 1,
-                                        match: { system: fixedSystem },
+                                        match: { system: fixedSystem, code: "PKV" },
                                     },
                                 },
                             },
@@ -171,7 +171,9 @@ describe("TypeScript profile fixed CodeableConcept semantics", async () => {
         expect(profileFile).toBeDefined();
         const profileTs = profileFile![1];
 
-        expect(profileTs).toContain(`applyFixedValue(resource, "type", {"coding":[{"system":"${fixedSystem}"}]})`);
+        expect(profileTs).toContain(
+            `applyFixedValue(resource, "type", {"coding":[{"system":"${fixedSystem}","code":"PKV"}]})`,
+        );
         expect(profileTs).not.toContain("Object.assign(resource");
         expect(profileTs).not.toContain(`validateEnum(res, profileName, "type", ["UNK"])`);
         expect(profileTs).not.toContain(`CodeableConcept<("UNK")>`);

--- a/test/unit/api/writer-generator/typescript/profile-slices.test.ts
+++ b/test/unit/api/writer-generator/typescript/profile-slices.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { sliceAccessorBaseName } from "@root/api/writer-generator/typescript/profile-slices";
+
+describe("sliceAccessorBaseName", () => {
+    test("qualifies a slice accessor that collides with an inherited field accessor", () => {
+        expect(
+            sliceAccessorBaseName(["Category", "ComponentCategory", "ComponentCategorySlice"], "Category", [
+                "category",
+                "component",
+            ]),
+        ).toBe("ComponentCategory");
+    });
+
+    test("keeps a collision-free recommended slice accessor", () => {
+        expect(sliceAccessorBaseName(["SystolicBP", "ComponentSystolicBP"], "SystolicBP", ["component"])).toBe(
+            "SystolicBP",
+        );
+    });
+});

--- a/test/unit/api/writer-generator/typescript/profile-slices.test.ts
+++ b/test/unit/api/writer-generator/typescript/profile-slices.test.ts
@@ -16,4 +16,14 @@ describe("sliceAccessorBaseName", () => {
             "SystolicBP",
         );
     });
+
+    test("allocates a distinct accessor when an earlier slice selected the same candidate", () => {
+        const candidates = ["Category", "ComponentCategory", "OtherComponentCategory"];
+        const fieldNames = ["category", "component"];
+        const first = sliceAccessorBaseName(candidates, "Category", fieldNames);
+        const second = sliceAccessorBaseName(candidates, "Category", fieldNames, new Set([first]));
+
+        expect(first).toBe("ComponentCategory");
+        expect(second).toBe("OtherComponentCategory");
+    });
 });

--- a/test/unit/typeschema/field-builder.test.ts
+++ b/test/unit/typeschema/field-builder.test.ts
@@ -195,6 +195,42 @@ describe("Field Builder Core Logic", async () => {
             expect(field.type?.name).toBe("string" as Name);
         });
 
+        it("does not fix a CodeableConcept from a system-only required coding slice", () => {
+            const codingSlice = {
+                min: 1,
+                match: { system: "http://snomed.info/sct" },
+            };
+            const rawElement = {
+                type: "CodeableConcept",
+                elements: {
+                    coding: {
+                        type: "Coding",
+                        array: true,
+                        slicing: {
+                            slices: { snomed: codingSlice },
+                        },
+                    },
+                },
+            } as unknown as FHIRSchemaElement;
+            const fhirSchema: PFS = {
+                name: "Specimen",
+                type: "Specimen",
+                kind: "resource",
+                url: "http://hl7.org/fhir/StructureDefinition/Specimen",
+            };
+
+            const field = mkField(
+                r4,
+                registerFs(r4, fhirSchema),
+                ["type"],
+                { type: "CodeableConcept" },
+                undefined,
+                rawElement,
+            ) as RegularField;
+
+            expect(field.valueConstraint).toBeUndefined();
+        });
+
         it("should handle min and max constraints", async () => {
             const element: FHIRSchemaElement = {
                 type: "integer",


### PR DESCRIPTION
## Summary

- Keep system-only required `Coding` slices as constraints instead of promoting them to a fully fixed parent `CodeableConcept`, preserving user-supplied codes.
- Allocate slice accessor names against inherited profile fields and accessor names already selected for earlier slices.
- Preserve generated profile inputs when those collision cases occur.

## Motivation

A required coding slice whose discriminator fixes only `system` still expects the resource author to provide `code`. Treating the parent `CodeableConcept` as fixed drops that input. Separately, a slice accessor can collide with an inherited field accessor or with another slice's chosen fallback name.

## Verification

- `bun test test/unit/api/writer-generator/typescript/profile-slices.test.ts test/unit/typeschema/field-builder.test.ts test/api/write-generator/typescript.test.ts`
  - 40 passed, 0 failed
- `bun run build`
  - passed
