### PR TITLE
FHIR R4: support virtual Base for logical models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@atomic-ehr/fhir-canonical-manager": "0.0.24",
         "@atomic-ehr/fhirschema": "0.0.14",
-        "brace-expansion": "^5.0.8",
+        "brace-expansion": "^5.0.9",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
         "yaml": "^2.9.0",
@@ -26,7 +26,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "esbuild": ">=0.28.1",
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
@@ -282,7 +282,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@atomic-ehr/fhir-canonical-manager": "0.0.24",
     "@atomic-ehr/fhirschema": "0.0.14",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "mustache": "^4.2.0",
     "picocolors": "^1.1.1",
     "yaml": "^2.9.0",
@@ -69,7 +69,7 @@
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
     "smol-toml": ">=1.6.1",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"
   }

--- a/src/typeschema/core/transformer.ts
+++ b/src/typeschema/core/transformer.ts
@@ -147,9 +147,7 @@ export function transformFhirSchema(register: Register, fhirSchema: RichFHIRSche
         const baseUrl = register.ensureSpecializationCanonicalUrl(fhirSchema.base);
         const baseFs = register.resolveFs(fhirSchema.package_meta, baseUrl);
         const isVirtualLogicalBase =
-            fhirSchema.kind === "logical" &&
-            fhirSchema.derivation === "specialization" &&
-            isFhirBaseCanonical(baseUrl);
+            fhirSchema.kind === "logical" && fhirSchema.derivation === "specialization" && isFhirBaseCanonical(baseUrl);
         if (!baseFs && !isVirtualLogicalBase)
             throw new Error(
                 `Base resource not found '${fhirSchema.base}' for <${fhirSchema.url}> from ${packageMetaToFhir(fhirSchema.package_meta)}`,

--- a/src/typeschema/core/transformer.ts
+++ b/src/typeschema/core/transformer.ts
@@ -8,7 +8,7 @@ import assert from "node:assert";
 import type { FHIRSchemaElement } from "@atomic-ehr/fhirschema";
 import { shouldSkipCanonical } from "@root/typeschema/skip-hack";
 import type { CodegenLog } from "@root/utils/log";
-import type { Register } from "@typeschema/register";
+import { isFhirBaseCanonical, type Register } from "@typeschema/register";
 import {
     concatIdentifiers,
     extractExtensionDeps,
@@ -144,17 +144,21 @@ export const extractProfileDependencies = (
 export function transformFhirSchema(register: Register, fhirSchema: RichFHIRSchema, logger?: CodegenLog): TypeSchema[] {
     let base: Identifier | undefined;
     if (fhirSchema.base) {
-        const baseFs = register.resolveFs(
-            fhirSchema.package_meta,
-            register.ensureSpecializationCanonicalUrl(fhirSchema.base),
-        );
-        if (!baseFs)
+        const baseUrl = register.ensureSpecializationCanonicalUrl(fhirSchema.base);
+        const baseFs = register.resolveFs(fhirSchema.package_meta, baseUrl);
+        const isVirtualLogicalBase =
+            fhirSchema.kind === "logical" &&
+            fhirSchema.derivation === "specialization" &&
+            isFhirBaseCanonical(baseUrl);
+        if (!baseFs && !isVirtualLogicalBase)
             throw new Error(
                 `Base resource not found '${fhirSchema.base}' for <${fhirSchema.url}> from ${packageMetaToFhir(fhirSchema.package_meta)}`,
             );
-        const baseId = mkIdentifier(baseFs);
-        assert(!isNestedIdentifier(baseId), `Unexpected nested base for ${fhirSchema.url}`);
-        base = baseId;
+        if (baseFs) {
+            const baseId = mkIdentifier(baseFs);
+            assert(!isNestedIdentifier(baseId), `Unexpected nested base for ${fhirSchema.url}`);
+            base = baseId;
+        }
     }
 
     const { fields, slicing } = mkFields(register, fhirSchema, [], fhirSchema.elements, logger);

--- a/src/typeschema/register.ts
+++ b/src/typeschema/register.ts
@@ -19,6 +19,9 @@ import type {
 import { enrichFHIRSchema, enrichValueSet, packageMetaToFhir, packageMetaToNpm } from "@typeschema/types";
 
 const BARE_RESOURCE_NAME_RE = /^[a-zA-Z0-9]+$/;
+const FHIR_BASE_CANONICAL = "http://hl7.org/fhir/StructureDefinition/Base";
+
+export const isFhirBaseCanonical = (canonical: string): boolean => canonical.split("|")[0] === FHIR_BASE_CANONICAL;
 
 export type Register = {
     testAppendFs(fs: FHIRSchema): void;
@@ -239,6 +242,7 @@ export const registerFromManager = async (
         while (fs?.base) {
             const pkg = fs.package_meta;
             const baseUrl = ensureSpecializationCanonicalUrl(fs.base);
+            if (fs.kind === "logical" && fs.derivation === "specialization" && isFhirBaseCanonical(baseUrl)) break;
             fs = resolveFs(pkg, baseUrl);
             if (fs === undefined)
                 throw new Error(

--- a/test/unit/typeschema/transformer/hierarchy.test.ts
+++ b/test/unit/typeschema/transformer/hierarchy.test.ts
@@ -118,6 +118,53 @@ describe("TypeSchema: Nested types", async () => {
     });
 });
 
+describe("TypeSchema: FHIR logical model roots", async () => {
+    const r4 = await mkR4Register();
+    const logger = mkTestLogger();
+
+    for (const base of [
+        "http://hl7.org/fhir/StructureDefinition/Base|4.0.1",
+        "http://hl7.org/fhir/StructureDefinition/Base",
+    ]) {
+        it(`accepts virtual logical-model root ${base}`, async () => {
+            const logicalModel: PFS = {
+                base,
+                url: `http://example.org/StructureDefinition/Document-${base.includes("|") ? "versioned" : "plain"}`,
+                name: "Document",
+                kind: "logical",
+                derivation: "specialization",
+                elements: {
+                    title: { type: "string" },
+                },
+            };
+
+            expect(await registerFsAndMkTs(r4, logicalModel, logger)).toMatchObject([
+                {
+                    identifier: { kind: "logical", name: "Document" },
+                    base: undefined,
+                    fields: {
+                        title: { type: { name: "string" } },
+                    },
+                },
+            ]);
+        });
+    }
+
+    it("still rejects a logical model with an unknown missing parent", async () => {
+        const logicalModel: PFS = {
+            base: "http://example.org/StructureDefinition/MissingParent",
+            url: "http://example.org/StructureDefinition/BrokenDocument",
+            name: "BrokenDocument",
+            kind: "logical",
+            derivation: "specialization",
+        };
+
+        await expect(registerFsAndMkTs(r4, logicalModel, logger)).rejects.toThrow(
+            "Base resource not found 'http://example.org/StructureDefinition/MissingParent'",
+        );
+    });
+});
+
 const viewDefinitionSD = {
     name: "ViewDefinition",
     url: "https://sql-on-fhir.org/ig/StructureDefinition/ViewDefinition",


### PR DESCRIPTION
## Summary

- treat the FHIR R4 `Base` canonical as the virtual root of logical specialization models
- support both versioned (`Base|4.0.1`) and unversioned canonical references
- retain the existing error for every other unresolved base

## Why

FHIR R4 defines `Base` as a virtual root and does not ship a physical `StructureDefinition-Base.json`. Logical models such as IPS 2.0.1 `Document` and `DocumentSection` legitimately specialize it, so requiring a resolvable package resource rejects valid models accepted by the HL7 Publisher.

## Verification

- `bun test test/unit/typeschema/transformer/hierarchy.test.ts test/unit/typeschema/register.test.ts` (14 pass)
- `bun run typecheck`
- `bun run build`
- Polaris `packages/fhir-de` generation with the local `de.cognovis.fhir.praxis@0.96.0` candidate containing `hl7.fhir.uv.ips#2.0.1` proceeds through conversion and successful TypeScript generation of the Praxis package; the former `Base|4.0.1` failure is gone

