### PR TITLE
TypeSchema/TS/PY: validate sliced choice components with at-least-one semantics

### DIFF
--- a/assets/api/writer-generator/python/profile_helpers.py
+++ b/assets/api/writer-generator/python/profile_helpers.py
@@ -451,9 +451,15 @@ def validate_slice_fields(
     match: Mapping[str, Any],
     slice_name: str,
     required_fields: Sequence[str],
+    choice_groups: Sequence[Sequence[str]] = (),
 ) -> list[str]:
     """Validates required fields within matched slice elements. For each array
-    item matching the discriminator, checks that the listed fields are present."""
+    item matching the discriminator, checks that the listed fields are present.
+
+    ``choice_groups`` carries the required choice elements of the slice: each
+    group lists the typed variants a single ``value[x]``-style element may take,
+    and is satisfied by any one of them. E.g. ``[["valueCoding"]]`` for a slice
+    whose ``value[x]`` is required and narrowed to Coding."""
     items = _get_field(res, field) or []
     if not isinstance(items, Iterable):
         items = []
@@ -464,6 +470,14 @@ def validate_slice_fields(
         for rf in required_fields:
             if _get_field(item, rf) is None:
                 errors.append(f"{profile_name}.{field}[{slice_name}].{rf} is required")
+        for group in choice_groups:
+            if any(_get_field(item, variant) is not None for variant in group):
+                continue
+            errors.append(
+                f"{profile_name}.{field}[{slice_name}].{group[0]} is required"
+                if len(group) == 1
+                else f"{profile_name}.{field}[{slice_name}]: at least one of {', '.join(group)} is required"
+            )
     return errors
 
 

--- a/assets/api/writer-generator/typescript/profile-helpers.ts
+++ b/assets/api/writer-generator/typescript/profile-helpers.ts
@@ -404,6 +404,11 @@ export const validateSliceCardinality = (
 /**
  * Validate required fields within matched slice elements.
  * For each array item matching the discriminator, checks that the listed fields are present.
+ *
+ * `choiceGroups` carries the required choice elements of the slice: each group
+ * lists the typed variants a single `value[x]`-style element may take, and is
+ * satisfied by any one of them. E.g. `[["valueCodeableConcept"]]` for a slice
+ * whose `value[x]` is required and narrowed to CodeableConcept.
  */
 export const validateSliceFields = (
     res: object,
@@ -412,15 +417,26 @@ export const validateSliceFields = (
     match: Record<string, unknown>,
     sliceName: string,
     requiredFields: string[],
+    choiceGroups: string[][] = [],
 ): string[] => {
     const items = (res as Record<string, unknown>)[field] as unknown[] | undefined;
     const errors: string[] = [];
+    const isPresent = (obj: Record<string, unknown>, key: string): boolean =>
+        obj[key] !== undefined && obj[key] !== null;
     for (const item of (items ?? []).filter((item) => matchesValue(item, match))) {
         const obj = item as Record<string, unknown>;
         for (const rf of requiredFields) {
-            if (obj[rf] === undefined || obj[rf] === null) {
+            if (!isPresent(obj, rf)) {
                 errors.push(`${profileName}.${field}[${sliceName}].${rf} is required`);
             }
+        }
+        for (const group of choiceGroups) {
+            if (group.some((variant) => isPresent(obj, variant))) continue;
+            errors.push(
+                group.length === 1
+                    ? `${profileName}.${field}[${sliceName}].${group[0]} is required`
+                    : `${profileName}.${field}[${sliceName}]: at least one of ${group.join(", ")} is required`,
+            );
         }
     }
     return errors;

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@atomic-ehr/fhir-canonical-manager": "0.0.24",
         "@atomic-ehr/fhirschema": "0.0.14",
-        "brace-expansion": "^5.0.8",
+        "brace-expansion": "^5.0.9",
         "mustache": "^4.2.0",
         "picocolors": "^1.1.1",
         "yaml": "^2.9.0",
@@ -26,7 +26,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "esbuild": ">=0.28.1",
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
@@ -282,7 +282,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/examples/python-r4-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_ethnicity_extension.py
+++ b/examples/python-r4-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_ethnicity_extension.py
@@ -216,17 +216,17 @@ class UscoreEthnicityExtension:
         errors.extend(validate_required(self._resource, profile_name, "extension"))
         errors.extend(validate_slice_cardinality(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", 0, 1))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", [
-                "value","valueCoding"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", [], [
+                ["valueCoding"]
         ]))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"detailed"}, "detailed", [
-                "value","valueCoding"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"detailed"}, "detailed", [], [
+                ["valueCoding"]
         ]))
         errors.extend(validate_slice_cardinality(self._resource, profile_name, "extension", {"url":"text"}, "text", 1, 1))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"text"}, "text", [
-                "value","valueString"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"text"}, "text", [], [
+                ["valueString"]
         ]))
         errors.extend(validate_required(self._resource, profile_name, "url"))
         errors.extend(validate_fixed_value(self._resource, profile_name, "url", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"))

--- a/examples/python-r4-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_race_extension.py
+++ b/examples/python-r4-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_race_extension.py
@@ -219,17 +219,17 @@ class UscoreRaceExtension:
         errors.extend(validate_required(self._resource, profile_name, "extension"))
         errors.extend(validate_slice_cardinality(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", 0, 6))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", [
-                "value","valueCoding"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", [], [
+                ["valueCoding"]
         ]))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"detailed"}, "detailed", [
-                "value","valueCoding"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"detailed"}, "detailed", [], [
+                ["valueCoding"]
         ]))
         errors.extend(validate_slice_cardinality(self._resource, profile_name, "extension", {"url":"text"}, "text", 1, 1))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"text"}, "text", [
-                "value","valueString"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"text"}, "text", [], [
+                ["valueString"]
         ]))
         errors.extend(validate_required(self._resource, profile_name, "url"))
         errors.extend(validate_fixed_value(self._resource, profile_name, "url", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"))

--- a/examples/python-r4-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_tribal_affiliation_extension.py
+++ b/examples/python-r4-us-core/fhir_types/hl7_fhir_us_core/profiles/extension_uscore_tribal_affiliation_extension.py
@@ -166,13 +166,13 @@ class UscoreTribalAffiliationExtension:
         errors.extend(validate_required(self._resource, profile_name, "extension"))
         errors.extend(validate_slice_cardinality(self._resource, profile_name, "extension", {"url":"tribalAffiliation"}, "tribalAffiliation", 1, 1))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"tribalAffiliation"}, "tribalAffiliation", [
-                "value","valueCodeableConcept"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"tribalAffiliation"}, "tribalAffiliation", [], [
+                ["valueCodeableConcept"]
         ]))
         errors.extend(validate_slice_cardinality(self._resource, profile_name, "extension", {"url":"isEnrolled"}, "isEnrolled", 0, 1))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"isEnrolled"}, "isEnrolled", [
-                "value","valueBoolean"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"isEnrolled"}, "isEnrolled", [], [
+                ["valueBoolean"]
         ]))
         errors.extend(validate_required(self._resource, profile_name, "url"))
         errors.extend(validate_fixed_value(self._resource, profile_name, "url", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation"))

--- a/examples/python-r4-us-core/fhir_types/profile_helpers.py
+++ b/examples/python-r4-us-core/fhir_types/profile_helpers.py
@@ -451,9 +451,15 @@ def validate_slice_fields(
     match: Mapping[str, Any],
     slice_name: str,
     required_fields: Sequence[str],
+    choice_groups: Sequence[Sequence[str]] = (),
 ) -> list[str]:
     """Validates required fields within matched slice elements. For each array
-    item matching the discriminator, checks that the listed fields are present."""
+    item matching the discriminator, checks that the listed fields are present.
+
+    ``choice_groups`` carries the required choice elements of the slice: each
+    group lists the typed variants a single ``value[x]``-style element may take,
+    and is satisfied by any one of them. E.g. ``[["valueCoding"]]`` for a slice
+    whose ``value[x]`` is required and narrowed to Coding."""
     items = _get_field(res, field) or []
     if not isinstance(items, Iterable):
         items = []
@@ -464,6 +470,14 @@ def validate_slice_fields(
         for rf in required_fields:
             if _get_field(item, rf) is None:
                 errors.append(f"{profile_name}.{field}[{slice_name}].{rf} is required")
+        for group in choice_groups:
+            if any(_get_field(item, variant) is not None for variant in group):
+                continue
+            errors.append(
+                f"{profile_name}.{field}[{slice_name}].{group[0]} is required"
+                if len(group) == 1
+                else f"{profile_name}.{field}[{slice_name}]: at least one of {', '.join(group)} is required"
+            )
     return errors
 
 

--- a/examples/python-r4-us-core/test_profile_patient.py
+++ b/examples/python-r4-us-core/test_profile_patient.py
@@ -9,6 +9,7 @@ import warnings
 import pytest
 from fhir_types.hl7_fhir_r4_core.base import Coding, Extension, HumanName, Identifier
 from fhir_types.hl7_fhir_r4_core.patient import Patient
+from fhir_types.profile_helpers import validate_slice_fields
 from fhir_types.hl7_fhir_us_core.profiles.extension_uscore_ethnicity_extension import (
     UscoreEthnicityExtension,
 )
@@ -522,3 +523,58 @@ def test_profile_from_empty_resource_reports_missing_required_fields() -> None:
 
     assert "UscorePatientProfile: required field 'identifier' is missing" in errors
     assert "UscorePatientProfile: required field 'name' is missing" in errors
+
+
+# ---------------------------------------------------------------------------
+# Sliced choice validation
+#
+# The race extension slices `extension` and requires the choice element
+# `value[x]` inside each slice, narrowed to a single type. The choice base name
+# `value` is not a FHIR element, so requiring it made every conformant race
+# extension invalid. Each required choice element is satisfied by any one of its
+# permitted typed variants.
+# ---------------------------------------------------------------------------
+
+
+def test_race_extension_written_by_its_own_setters_is_valid() -> None:
+    race = UscoreRaceExtension.create()
+    race.set_extension_omb_category({"code": "2106-3", "display": "White"})
+    race.set_extension_text({"valueString": "White"})
+
+    assert race.validate()["errors"] == []
+
+
+def test_race_extension_slice_element_without_a_choice_variant_is_invalid() -> None:
+    race = UscoreRaceExtension.create()
+    race.set_extension_omb_category({})
+    race.set_extension_text({"valueString": "White"})
+
+    errors = race.validate()["errors"]
+
+    assert errors == ["UscoreRaceExtension.extension[ombCategory].valueCoding is required"]
+
+
+# A slice narrowing `value[x]` to more than one type has no US Core instance, so
+# the multi-variant branch of the helper is exercised directly.
+MULTI_VARIANT_GROUP = [["valueQuantity", "valueString"]]
+MEASURED_MATCH = {"code": "measured-finding"}
+
+
+def test_multi_variant_choice_group_is_satisfied_by_any_permitted_variant() -> None:
+    res = {"component": [{"code": "measured-finding", "valueString": "three millimetres"}]}
+
+    errors = validate_slice_fields(
+        res, "Demo", "component", MEASURED_MATCH, "measuredFinding", [], MULTI_VARIANT_GROUP
+    )
+
+    assert errors == []
+
+
+def test_multi_variant_choice_group_without_a_variant_names_every_permitted_variant() -> None:
+    res = {"component": [{"code": "measured-finding"}]}
+
+    errors = validate_slice_fields(
+        res, "Demo", "component", MEASURED_MATCH, "measuredFinding", [], MULTI_VARIANT_GROUP
+    )
+
+    assert errors == ["Demo.component[measuredFinding]: at least one of valueQuantity, valueString is required"]

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Extension_USCoreEthnicityExtension.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Extension_USCoreEthnicityExtension.ts
@@ -254,10 +254,10 @@ export class USCoreEthnicityExtensionProfile {
             errors: [
                 ...validateRequired(res, profileName, "extension"),
                 ...validateSliceCardinality(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", 0, 1),
-                ...validateSliceFields(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", ["value","valueCoding"]),
-                ...validateSliceFields(res, profileName, "extension", {"url":"detailed"}, "detailed", ["value","valueCoding"]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", [], [["valueCoding"]]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"detailed"}, "detailed", [], [["valueCoding"]]),
                 ...validateSliceCardinality(res, profileName, "extension", {"url":"text"}, "text", 1, 1),
-                ...validateSliceFields(res, profileName, "extension", {"url":"text"}, "text", ["value","valueString"]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"text"}, "text", [], [["valueString"]]),
                 ...validateRequired(res, profileName, "url"),
                 ...validateFixedValue(res, profileName, "url", USCoreEthnicityExtensionProfile.canonicalUrl),
             ],

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Extension_USCoreRaceExtension.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Extension_USCoreRaceExtension.ts
@@ -254,10 +254,10 @@ export class USCoreRaceExtensionProfile {
             errors: [
                 ...validateRequired(res, profileName, "extension"),
                 ...validateSliceCardinality(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", 0, 6),
-                ...validateSliceFields(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", ["value","valueCoding"]),
-                ...validateSliceFields(res, profileName, "extension", {"url":"detailed"}, "detailed", ["value","valueCoding"]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", [], [["valueCoding"]]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"detailed"}, "detailed", [], [["valueCoding"]]),
                 ...validateSliceCardinality(res, profileName, "extension", {"url":"text"}, "text", 1, 1),
-                ...validateSliceFields(res, profileName, "extension", {"url":"text"}, "text", ["value","valueString"]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"text"}, "text", [], [["valueString"]]),
                 ...validateRequired(res, profileName, "url"),
                 ...validateFixedValue(res, profileName, "url", USCoreRaceExtensionProfile.canonicalUrl),
             ],

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Extension_USCoreTribalAffiliationExtension.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Extension_USCoreTribalAffiliationExtension.ts
@@ -209,9 +209,9 @@ export class USCoreTribalAffiliationExtensionProfile {
             errors: [
                 ...validateRequired(res, profileName, "extension"),
                 ...validateSliceCardinality(res, profileName, "extension", {"url":"tribalAffiliation"}, "tribalAffiliation", 1, 1),
-                ...validateSliceFields(res, profileName, "extension", {"url":"tribalAffiliation"}, "tribalAffiliation", ["value","valueCodeableConcept"]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"tribalAffiliation"}, "tribalAffiliation", [], [["valueCodeableConcept"]]),
                 ...validateSliceCardinality(res, profileName, "extension", {"url":"isEnrolled"}, "isEnrolled", 0, 1),
-                ...validateSliceFields(res, profileName, "extension", {"url":"isEnrolled"}, "isEnrolled", ["value","valueBoolean"]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"isEnrolled"}, "isEnrolled", [], [["valueBoolean"]]),
                 ...validateRequired(res, profileName, "url"),
                 ...validateFixedValue(res, profileName, "url", USCoreTribalAffiliationExtensionProfile.canonicalUrl),
             ],

--- a/examples/typescript-r4-us-core/fhir-types/profile-helpers.ts
+++ b/examples/typescript-r4-us-core/fhir-types/profile-helpers.ts
@@ -404,6 +404,11 @@ export const validateSliceCardinality = (
 /**
  * Validate required fields within matched slice elements.
  * For each array item matching the discriminator, checks that the listed fields are present.
+ *
+ * `choiceGroups` carries the required choice elements of the slice: each group
+ * lists the typed variants a single `value[x]`-style element may take, and is
+ * satisfied by any one of them. E.g. `[["valueCodeableConcept"]]` for a slice
+ * whose `value[x]` is required and narrowed to CodeableConcept.
  */
 export const validateSliceFields = (
     res: object,
@@ -412,15 +417,26 @@ export const validateSliceFields = (
     match: Record<string, unknown>,
     sliceName: string,
     requiredFields: string[],
+    choiceGroups: string[][] = [],
 ): string[] => {
     const items = (res as Record<string, unknown>)[field] as unknown[] | undefined;
     const errors: string[] = [];
+    const isPresent = (obj: Record<string, unknown>, key: string): boolean =>
+        obj[key] !== undefined && obj[key] !== null;
     for (const item of (items ?? []).filter((item) => matchesValue(item, match))) {
         const obj = item as Record<string, unknown>;
         for (const rf of requiredFields) {
-            if (obj[rf] === undefined || obj[rf] === null) {
+            if (!isPresent(obj, rf)) {
                 errors.push(`${profileName}.${field}[${sliceName}].${rf} is required`);
             }
+        }
+        for (const group of choiceGroups) {
+            if (group.some((variant) => isPresent(obj, variant))) continue;
+            errors.push(
+                group.length === 1
+                    ? `${profileName}.${field}[${sliceName}].${group[0]} is required`
+                    : `${profileName}.${field}[${sliceName}]: at least one of ${group.join(", ")} is required`,
+            );
         }
     }
     return errors;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@atomic-ehr/fhir-canonical-manager": "0.0.24",
     "@atomic-ehr/fhirschema": "0.0.14",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "mustache": "^4.2.0",
     "picocolors": "^1.1.1",
     "yaml": "^2.9.0",
@@ -69,7 +69,7 @@
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
     "smol-toml": ">=1.6.1",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"
   }

--- a/src/api/writer-generator/python/profile-validation.ts
+++ b/src/api/writer-generator/python/profile-validation.ts
@@ -1,5 +1,6 @@
 import {
     type ChoiceFieldInstance,
+    type FieldSlice,
     type FieldSlicing,
     isChoiceDeclarationField,
     isChoiceInstanceField,
@@ -22,7 +23,7 @@ import { pyFieldName } from "./profile-naming";
  *              "85353-1","9279-1",...
  *      ]))
  */
-const pushListValidation = (lines: string[], target: string, fn: string, args: string[], items: string[]): void => {
+const pushListValidation = (lines: string[], target: string, fn: string, args: string[], items: unknown[]): void => {
     const argList = ["self._resource", "profile_name", ...args].join(", ");
     lines.push(
         `${target}.extend(`,
@@ -133,6 +134,43 @@ const collectRegularFieldValidation = (
     }
 };
 
+/**
+ * Split what a slice element must carry into plain required fields and choice
+ * groups. A required choice element (e.g. `value` for a sliced `value[x]`) is
+ * satisfied by any one of its permitted typed variants — the choice base name
+ * itself is not a FHIR element and can never be present on a conformant
+ * resource, so it must never be emitted as a plain required field.
+ *
+ * Mirrors `collectSliceRequirements` in the TypeScript writer.
+ */
+const collectSliceRequirements = (
+    slice: FieldSlice,
+    match: Record<string, unknown>,
+    field: RegularField | ChoiceFieldInstance,
+    tsIndex: TypeSchemaIndex,
+    formatName: (s: string) => string,
+): { requiredFields: string[]; choiceGroups: string[][] } => {
+    const requiredFields: string[] = [];
+    const choiceGroups: string[][] = [];
+    const matchKeys = new Set(Object.keys(match));
+    const requiredNames = (slice.required ?? []).filter((rf) => !matchKeys.has(rf));
+    const fieldType = field.type;
+    for (const rf of requiredNames) {
+        const variants = fieldType
+            ? tsIndex.sliceChoiceVariants(fieldType.package, fieldType, slice.elements ?? [], rf)
+            : undefined;
+        if (variants && variants.length > 0) choiceGroups.push(variants.map((v) => pyFieldName(v, formatName)));
+        else requiredFields.push(pyFieldName(rf, formatName));
+    }
+    // Constrained choice the slice does not state as required: the single
+    // permitted variant stands in for the choice element.
+    if (fieldType && slice.elements) {
+        const cc = tsIndex.constrainedChoice(fieldType.package, fieldType, slice.elements);
+        if (cc && !requiredNames.includes(cc.choiceBase)) requiredFields.push(pyFieldName(cc.variant, formatName));
+    }
+    return { requiredFields, choiceGroups };
+};
+
 const collectSliceValidation = (
     field: RegularField | ChoiceFieldInstance,
     fieldSlicing: FieldSlicing,
@@ -154,26 +192,22 @@ const collectSliceValidation = (
                 `errors.extend(validate_slice_cardinality(self._resource, profile_name, ${JSON.stringify(name)}, ${JSON.stringify(match)}, ${JSON.stringify(sliceName)}, ${min}, ${max}))`,
             );
         }
-        // Collect required fields within the slice element
-        const sliceRequiredFields: string[] = [];
-        const matchKeys = new Set(Object.keys(match));
-        for (const rf of slice.required ?? []) {
-            if (!matchKeys.has(rf)) sliceRequiredFields.push(pyFieldName(rf, formatName));
+        const { requiredFields, choiceGroups } = collectSliceRequirements(slice, match, field, tsIndex, formatName);
+        if (requiredFields.length === 0 && choiceGroups.length === 0) continue;
+        helpers.add("validate_slice_fields");
+        const args = [JSON.stringify(name), JSON.stringify(match), JSON.stringify(sliceName)];
+        if (choiceGroups.length === 0) {
+            pushListValidation(errorLines, "errors", "validate_slice_fields", args, requiredFields);
+            continue;
         }
-        // Constrained choice: the single variant is required
-        if (field.type && slice.elements) {
-            const cc = tsIndex.constrainedChoice(field.type.package, field.type, slice.elements);
-            if (cc) sliceRequiredFields.push(pyFieldName(cc.variant, formatName));
-        }
-        if (sliceRequiredFields.length > 0) {
-            helpers.add("validate_slice_fields");
-            pushListValidation(
-                errorLines,
-                "errors",
-                "validate_slice_fields",
-                [JSON.stringify(name), JSON.stringify(match), JSON.stringify(sliceName)],
-                sliceRequiredFields,
-            );
-        }
+        // The choice groups become the trailing list argument, so the plain
+        // required fields move into the inline argument list.
+        pushListValidation(
+            errorLines,
+            "errors",
+            "validate_slice_fields",
+            [...args, JSON.stringify(requiredFields)],
+            choiceGroups,
+        );
     }
 };

--- a/src/api/writer-generator/typescript/profile-validation.ts
+++ b/src/api/writer-generator/typescript/profile-validation.ts
@@ -1,5 +1,6 @@
 import {
     type ChoiceFieldInstance,
+    type FieldSlice,
     type FieldSlicing,
     isChoiceDeclarationField,
     isChoiceInstanceField,
@@ -10,6 +11,41 @@ import {
 import type { TypeSchemaIndex } from "@root/typeschema/utils";
 import { tsProfileClassName } from "./name";
 import type { TypeScript } from "./writer";
+
+/**
+ * Split what a slice element must carry into plain required fields and choice
+ * groups. A required choice element (e.g. `value` for a sliced `value[x]`) is
+ * satisfied by any one of its permitted typed variants — the choice base name
+ * itself is not a FHIR element and can never be present on a conformant
+ * resource, so it must never be emitted as a plain required field.
+ */
+const collectSliceRequirements = (
+    slice: FieldSlice,
+    match: Record<string, unknown>,
+    field: RegularField | ChoiceFieldInstance,
+    tsIndex?: TypeSchemaIndex,
+): { requiredFields: string[]; choiceGroups: string[][] } => {
+    const requiredFields: string[] = [];
+    const choiceGroups: string[][] = [];
+    const matchKeys = new Set(Object.keys(match));
+    const requiredNames = (slice.required ?? []).filter((rf) => !matchKeys.has(rf));
+    const fieldType = field.type;
+    for (const rf of requiredNames) {
+        const variants =
+            tsIndex && fieldType
+                ? tsIndex.sliceChoiceVariants(fieldType.package, fieldType, slice.elements ?? [], rf)
+                : undefined;
+        if (variants && variants.length > 0) choiceGroups.push(variants);
+        else requiredFields.push(rf);
+    }
+    // Constrained choice the slice does not state as required: the single
+    // permitted variant stands in for the choice element.
+    if (tsIndex && fieldType && slice.elements) {
+        const cc = tsIndex.constrainedChoice(fieldType.package, fieldType, slice.elements);
+        if (cc && !requiredNames.includes(cc.choiceBase)) requiredFields.push(cc.variant);
+    }
+    return { requiredFields, choiceGroups };
+};
 
 export const collectRegularFieldValidation = (
     errors: string[],
@@ -60,21 +96,16 @@ export const collectRegularFieldValidation = (
                     `...validateSliceCardinality(res, profileName, ${JSON.stringify(name)}, ${JSON.stringify(match)}, ${JSON.stringify(sliceName)}, ${min}, ${max})`,
                 );
             }
-            // Collect required fields within the slice element
-            const sliceRequiredFields: string[] = [];
-            const matchKeys = new Set(Object.keys(match));
-            for (const rf of slice.required ?? []) {
-                if (!matchKeys.has(rf)) sliceRequiredFields.push(rf);
-            }
-            // Constrained choice: the single variant is required
-            if (tsIndex && field.type && slice.elements) {
-                const cc = tsIndex.constrainedChoice(field.type.package, field.type, slice.elements);
-                if (cc) sliceRequiredFields.push(cc.variant);
-            }
-            if (sliceRequiredFields.length > 0) {
-                errors.push(
-                    `...validateSliceFields(res, profileName, ${JSON.stringify(name)}, ${JSON.stringify(match)}, ${JSON.stringify(sliceName)}, ${JSON.stringify(sliceRequiredFields)})`,
-                );
+            const { requiredFields, choiceGroups } = collectSliceRequirements(slice, match, field, tsIndex);
+            if (requiredFields.length > 0 || choiceGroups.length > 0) {
+                const args = [
+                    JSON.stringify(name),
+                    JSON.stringify(match),
+                    JSON.stringify(sliceName),
+                    JSON.stringify(requiredFields),
+                ];
+                if (choiceGroups.length > 0) args.push(JSON.stringify(choiceGroups));
+                errors.push(`...validateSliceFields(res, profileName, ${args.join(", ")})`);
             }
         }
     }

--- a/src/typeschema/utils.ts
+++ b/src/typeschema/utils.ts
@@ -359,6 +359,12 @@ export type TypeSchemaIndex = {
         baseTypeId: TypeIdentifier,
         sliceElements: string[],
     ) => ConstrainedChoiceInfo | undefined;
+    sliceChoiceVariants: (
+        pkgName: PkgName,
+        baseTypeId: TypeIdentifier,
+        sliceElements: string[],
+        name: string,
+    ) => string[] | undefined;
     isWithMetaField: (profile: ProfileTypeSchema | SnapshotProfileTypeSchema) => boolean;
     entityTree: () => EntityTree;
     exportTree: (filename: string) => Promise<void>;
@@ -782,6 +788,24 @@ export const mkTypeSchemaIndex = (
         return undefined;
     };
 
+    /** The choice variants a slice may carry for the choice declaration `name`
+     *  (e.g. `value` inside a sliced `component`): the variants the slice narrows
+     *  to, or every variant of the declaration when the slice narrows none.
+     *  Returns undefined when `name` is not a choice declaration — a plain field. */
+    const sliceChoiceVariants = (
+        pkgName: PkgName,
+        baseTypeId: TypeIdentifier,
+        sliceElements: string[],
+        name: string,
+    ): string[] | undefined => {
+        const baseSchema = resolveByUrl(pkgName, baseTypeId.url as CanonicalUrl);
+        if (!baseSchema || !("fields" in baseSchema) || !baseSchema.fields) return undefined;
+        const field = baseSchema.fields[name];
+        if (!field || !isChoiceDeclarationField(field)) return undefined;
+        const narrowed = field.choices.filter((c) => sliceElements.includes(c));
+        return narrowed.length > 0 ? narrowed : field.choices;
+    };
+
     const isWithMetaField = (profile: ProfileTypeSchema | SnapshotProfileTypeSchema): boolean => {
         const genealogy = tryHierarchy(profile);
         if (!genealogy) return false;
@@ -837,6 +861,7 @@ export const mkTypeSchemaIndex = (
         findLastSpecializationByIdentifier,
         flatProfile,
         constrainedChoice,
+        sliceChoiceVariants,
         isWithMetaField,
         entityTree,
         exportTree,

--- a/test/api/write-generator/__snapshots__/python.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/python.test.ts.snap
@@ -2091,17 +2091,17 @@ class UscoreRaceExtension:
         errors.extend(validate_required(self._resource, profile_name, "extension"))
         errors.extend(validate_slice_cardinality(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", 0, 6))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", [
-                "value","valueCoding"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", [], [
+                ["valueCoding"]
         ]))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"detailed"}, "detailed", [
-                "value","valueCoding"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"detailed"}, "detailed", [], [
+                ["valueCoding"]
         ]))
         errors.extend(validate_slice_cardinality(self._resource, profile_name, "extension", {"url":"text"}, "text", 1, 1))
         errors.extend(
-            validate_slice_fields(self._resource, profile_name, "extension", {"url":"text"}, "text", [
-                "value","valueString"
+            validate_slice_fields(self._resource, profile_name, "extension", {"url":"text"}, "text", [], [
+                ["valueString"]
         ]))
         errors.extend(validate_required(self._resource, profile_name, "url"))
         errors.extend(validate_fixed_value(self._resource, profile_name, "url", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"))

--- a/test/api/write-generator/__snapshots__/typescript.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/typescript.test.ts.snap
@@ -2362,10 +2362,10 @@ export class USCoreRaceExtensionProfile {
             errors: [
                 ...validateRequired(res, profileName, "extension"),
                 ...validateSliceCardinality(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", 0, 6),
-                ...validateSliceFields(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", ["value","valueCoding"]),
-                ...validateSliceFields(res, profileName, "extension", {"url":"detailed"}, "detailed", ["value","valueCoding"]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", [], [["valueCoding"]]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"detailed"}, "detailed", [], [["valueCoding"]]),
                 ...validateSliceCardinality(res, profileName, "extension", {"url":"text"}, "text", 1, 1),
-                ...validateSliceFields(res, profileName, "extension", {"url":"text"}, "text", ["value","valueString"]),
+                ...validateSliceFields(res, profileName, "extension", {"url":"text"}, "text", [], [["valueString"]]),
                 ...validateRequired(res, profileName, "url"),
                 ...validateFixedValue(res, profileName, "url", USCoreRaceExtensionProfile.canonicalUrl),
             ],

--- a/test/api/write-generator/profile-sliced-choice-python.test.ts
+++ b/test/api/write-generator/profile-sliced-choice-python.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import * as Path from "node:path";
+import { APIBuilder } from "@root/api/builder";
+import { mkSilentLogger } from "@typeschema-test/utils";
+
+const FIXTURE_PATH = Path.join(__dirname, "../../assets/profile-sliced-choice");
+
+const CODED_FINDING_MATCH =
+    '{"code":{"coding":[{"system":"http://example.test/CodeSystem/component-kind","code":"coded-finding"}]}}';
+const MEASURED_FINDING_MATCH =
+    '{"code":{"coding":[{"system":"http://example.test/CodeSystem/component-kind","code":"measured-finding"}]}}';
+
+/** The two emitted lines of a `validate_slice_fields` call carrying choice
+ *  groups, matched against a dedented copy of the module. */
+const sliceFieldsCall = (match: string, sliceName: string, requiredFields: string, groups: string): string =>
+    [
+        `validate_slice_fields(self._resource, profile_name, "component", ${match}, "${sliceName}", ${requiredFields}, [`,
+        groups,
+    ].join("\n");
+
+/**
+ * Regression, the Python twin of the TypeScript sliced choice fix: a slice that
+ * constrains a choice element (`Observation.component:codedFinding.value[x]`
+ * narrowed to CodeableConcept and required) used to be validated with all-of
+ * semantics over `["value", "valueCodeableConcept"]`. `value` is not a FHIR
+ * element on a flattened resource, so no conformant resource could ever satisfy
+ * the generated validator.
+ *
+ * The fixture is the generic StructureDefinition of the TypeScript test, so the
+ * fix has to be generic too.
+ */
+describe("Python sliced choice component validation", async () => {
+    const result = await new APIBuilder({ logger: mkSilentLogger() })
+        .localStructureDefinitions({
+            package: { name: "example.test.slicedchoice", version: "0.0.1" },
+            path: FIXTURE_PATH,
+            dependencies: [{ name: "hl7.fhir.r4.core", version: "4.0.1" }],
+        })
+        .python({ inMemoryOnly: true, generateProfile: true, client: "none" })
+        .generate();
+
+    const profileKey = "generated/example_test_slicedchoice/profiles/observation_sliced_choice_observation.py";
+    const profileFile = result.filesGenerated.python?.[profileKey];
+    const dedented = (profileFile ?? "").replace(/^[ \t]+/gm, "");
+
+    it("should succeed", () => {
+        expect(result.success).toBeTrue();
+        expect(profileFile).toBeDefined();
+    });
+
+    it("does not require the choice base name inside a slice", () => {
+        expect(profileFile).not.toContain('"value","valueCodeableConcept"');
+        expect(dedented).not.toMatch(/validate_slice_fields\([^\n]*\n"value"[,\n]/);
+    });
+
+    it("emits an at-least-one choice group for a single-variant sliced choice element", () => {
+        expect(dedented).toContain(
+            sliceFieldsCall(CODED_FINDING_MATCH, "codedFinding", "[]", '["valueCodeableConcept"]'),
+        );
+    });
+
+    it("emits every permitted variant in the choice group of a two-type slice", () => {
+        expect(dedented).toContain(
+            sliceFieldsCall(MEASURED_FINDING_MATCH, "measuredFinding", "[]", '["valueQuantity","valueString"]'),
+        );
+    });
+});

--- a/test/api/write-generator/profile-sliced-choice.test.ts
+++ b/test/api/write-generator/profile-sliced-choice.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as Path from "node:path";
+import { APIBuilder } from "@root/api/builder";
+import { mkSilentLogger } from "@typeschema-test/utils";
+
+const FIXTURE_PATH = Path.join(__dirname, "../../assets/profile-sliced-choice");
+const HELPERS_PATH = Path.join(__dirname, "../../../assets/api/writer-generator/typescript/profile-helpers.ts");
+
+const CODED_FINDING_MATCH =
+    '{"code":{"coding":[{"system":"http://example.test/CodeSystem/component-kind","code":"coded-finding"}]}}';
+const MEASURED_FINDING_MATCH =
+    '{"code":{"coding":[{"system":"http://example.test/CodeSystem/component-kind","code":"measured-finding"}]}}';
+
+type ProfileInstance = {
+    setCodedFinding: (input?: Record<string, unknown>) => unknown;
+    setMeasuredFinding: (input?: Record<string, unknown>) => unknown;
+    toResource: () => Record<string, unknown>;
+};
+
+type ProfileClass = {
+    createResource: (args: Record<string, unknown>) => Record<string, unknown>;
+    apply: (resource: Record<string, unknown>) => ProfileInstance;
+    from: (resource: Record<string, unknown>) => unknown;
+};
+
+/**
+ * Write the generated profile module next to a copy of the runtime helper asset
+ * and import it, so the assertions run against the real generated setter and the
+ * real generated validator rather than against emitted source text.
+ */
+const loadProfileModule = async (relativePath: string, source: string): Promise<ProfileClass> => {
+    const dir = await fs.mkdtemp(Path.join(os.tmpdir(), "codegen-sliced-choice-"));
+    const dest = Path.join(dir, relativePath);
+    await fs.mkdir(Path.dirname(dest), { recursive: true });
+    await fs.writeFile(dest, source);
+    // The generated module imports "../../profile-helpers".
+    const helpersDest = Path.resolve(Path.dirname(dest), "../../profile-helpers.ts");
+    await fs.mkdir(Path.dirname(helpersDest), { recursive: true });
+    await fs.copyFile(HELPERS_PATH, helpersDest);
+    const mod = await import(dest);
+    return mod.SlicedChoiceObservationProfile as ProfileClass;
+};
+
+/**
+ * Regression: a slice that constrains a choice element
+ * (`Observation.component:codedFinding.value[x]` narrowed to CodeableConcept and
+ * required) used to be validated with all-of semantics over
+ * `["value", "valueCodeableConcept"]`. `value` is not a FHIR element, so no
+ * conformant resource — not even one written by the profile's own generated
+ * setter — could ever satisfy the generated validator.
+ *
+ * The fixture is a generic StructureDefinition, not a copy of the profile the
+ * defect was reported on, so the fix has to be generic too.
+ */
+describe("Sliced choice component validation", async () => {
+    const result = await new APIBuilder({ logger: mkSilentLogger() })
+        .localStructureDefinitions({
+            package: { name: "example.test.slicedchoice", version: "0.0.1" },
+            path: FIXTURE_PATH,
+            dependencies: [{ name: "hl7.fhir.r4.core", version: "4.0.1" }],
+        })
+        .typescript({ inMemoryOnly: true, generateProfile: true, withDebugComment: false })
+        .generate();
+
+    const profileKey = Object.keys(result.filesGenerated.typescript ?? {}).find((k) =>
+        k.includes("Observation_SlicedChoiceObservation"),
+    );
+    const profileFile = profileKey ? result.filesGenerated.typescript![profileKey] : undefined;
+
+    it("should succeed", () => {
+        expect(result.success).toBeTrue();
+        expect(profileFile).toBeDefined();
+    });
+
+    it("does not require the choice base name inside the slice", () => {
+        expect(profileFile).not.toContain(`"codedFinding", ["value"`);
+    });
+
+    it("emits an at-least-one choice group for the sliced choice element", () => {
+        expect(profileFile).toContain(
+            `validateSliceFields(res, profileName, "component", ${CODED_FINDING_MATCH}, "codedFinding", [], [["valueCodeableConcept"]])`,
+        );
+    });
+
+    const profileClass = await loadProfileModule(profileKey ?? "profile.ts", profileFile ?? "");
+
+    const baseArgs = {
+        status: "final",
+        code: { coding: [{ system: "http://example.test/CodeSystem/observation-kind", code: "example" }] },
+    };
+
+    it("accepts a slice element written by the profile's own generated setter", () => {
+        const profile = profileClass.apply(profileClass.createResource(baseArgs));
+        profile.setCodedFinding({ coding: [{ system: "http://example.test/CodeSystem/finding", code: "present" }] });
+        const resource = profile.toResource();
+
+        expect(() => profileClass.from(resource)).not.toThrow();
+    });
+
+    it("still rejects a slice element that carries no choice variant at all", () => {
+        const profile = profileClass.apply(profileClass.createResource(baseArgs));
+        profile.setCodedFinding({});
+        const resource = profile.toResource();
+
+        expect(() => profileClass.from(resource)).toThrow(/valueCodeableConcept is required/);
+    });
+
+    // The `measuredFinding` slice narrows value[x] to two types, so the choice
+    // group holds more than one variant: any one of them satisfies it.
+    const withCodedFinding = (): ProfileInstance => {
+        const profile = profileClass.apply(profileClass.createResource(baseArgs));
+        profile.setCodedFinding({ coding: [{ system: "http://example.test/CodeSystem/finding", code: "present" }] });
+        return profile;
+    };
+
+    it("emits every permitted variant in the choice group of a two-type slice", () => {
+        expect(profileFile).toContain(
+            `validateSliceFields(res, profileName, "component", ${MEASURED_FINDING_MATCH}, "measuredFinding", [], [["valueQuantity","valueString"]])`,
+        );
+    });
+
+    it("accepts the first permitted variant of a multi-variant choice slice", () => {
+        const profile = withCodedFinding();
+        profile.setMeasuredFinding({ valueQuantity: { value: 3, unit: "mm" } });
+
+        expect(() => profileClass.from(profile.toResource())).not.toThrow();
+    });
+
+    it("accepts the second permitted variant of a multi-variant choice slice", () => {
+        const profile = withCodedFinding();
+        profile.setMeasuredFinding({ valueString: "three millimetres" });
+
+        expect(() => profileClass.from(profile.toResource())).not.toThrow();
+    });
+
+    it("rejects a multi-variant choice slice carrying none of the permitted variants", () => {
+        const profile = withCodedFinding();
+        profile.setMeasuredFinding({});
+
+        expect(() => profileClass.from(profile.toResource())).toThrow(
+            "SlicedChoiceObservation.component[measuredFinding]: at least one of valueQuantity, valueString is required",
+        );
+    });
+});

--- a/test/assets/profile-sliced-choice/observation-sliced-choice.json
+++ b/test/assets/profile-sliced-choice/observation-sliced-choice.json
@@ -1,0 +1,95 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "sliced-choice-observation",
+  "url": "http://example.test/StructureDefinition/sliced-choice-observation",
+  "version": "0.1.0",
+  "name": "SlicedChoiceObservation",
+  "title": "Sliced Choice Observation",
+  "status": "active",
+  "description": "Generic regression fixture: an Observation profile whose component slice constrains the choice element value[x] to a single type and makes it required.",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.component",
+        "path": "Observation.component",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "pattern",
+              "path": "code"
+            }
+          ],
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Observation.component:codedFinding",
+        "path": "Observation.component",
+        "sliceName": "codedFinding",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Observation.component:codedFinding.code",
+        "path": "Observation.component.code",
+        "min": 1,
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://example.test/CodeSystem/component-kind",
+              "code": "coded-finding"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Observation.component:codedFinding.value[x]",
+        "path": "Observation.component.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ]
+      },
+      {
+        "id": "Observation.component:measuredFinding",
+        "path": "Observation.component",
+        "sliceName": "measuredFinding",
+        "max": "1"
+      },
+      {
+        "id": "Observation.component:measuredFinding.code",
+        "path": "Observation.component.code",
+        "min": 1,
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://example.test/CodeSystem/component-kind",
+              "code": "measured-finding"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Observation.component:measuredFinding.value[x]",
+        "path": "Observation.component.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "Quantity"
+          },
+          {
+            "code": "string"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Generated profile validators reject every conformant resource whose profile has a required choice element inside a slice. The emitted required-field list contains the choice **base** name (`value`), which never exists on a flattened FHIR resource — only the typed form does. The generator contradicts its own setter: `wrapSliceChoice` writes `valueCodeableConcept` alone, and then `validate()` demands `value`.

This reproduces on this repository's own US Core example: a race extension built with `Extension_USCoreRaceExtension`'s generated setters cannot pass its own `validate()`.

## Fix

- `sliceChoiceVariants(pkgName, baseTypeId, sliceElements, name)` in `src/typeschema/utils.ts` resolves the choice variants a slice may carry — the narrowed subset, or all variants when the slice narrows none, and `undefined` when the name is a plain field.
- Both writers now split a slice's requirements into two kinds, instead of concatenating them into one all-of list:
  - plain required fields keep all-of semantics, unchanged;
  - a required choice element becomes one at-least-one group over its permitted variants, and its base name is never emitted as a plain required field.
- Writer-side entry points:
  - TypeScript — `collectSliceRequirements` in `src/api/writer-generator/typescript/profile-validation.ts`; `validateSliceFields` gains an optional 7th parameter `choiceGroups: string[][] = []`.
  - Python — the mirror in `src/api/writer-generator/python/profile-validation.ts`; `validate_slice_fields` gains `choice_groups: Sequence[Sequence[str]] = ()`.
- The pre-existing constrained-choice fallback now fires only when the slice does not already state the choice base as required, so no error is duplicated or lost.
- Both new parameters are optional and default to empty, and the argument is omitted entirely when a slice has no choice groups — so existing call sites and previously generated code are unaffected, and emission for slices without a required choice element is byte-identical to before.

## Generated output

The old list could never be satisfied, because `value` is not an element on a conformant resource.

`examples/typescript-r4-us-core` → `Extension_USCoreRaceExtension.ts`:

```ts
// before
...validateSliceFields(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", ["value","valueCoding"]),
...validateSliceFields(res, profileName, "extension", {"url":"text"}, "text", ["value","valueString"]),

// after
...validateSliceFields(res, profileName, "extension", {"url":"ombCategory"}, "ombCategory", [], [["valueCoding"]]),
...validateSliceFields(res, profileName, "extension", {"url":"text"}, "text", [], [["valueString"]]),
```

`examples/python-r4-us-core` → `extension_uscore_race_extension.py`:

```python
# before
errors.extend(
    validate_slice_fields(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", [
        "value","valueCoding"
]))

# after
errors.extend(
    validate_slice_fields(self._resource, profile_name, "extension", {"url":"ombCategory"}, "ombCategory", [], [
        ["valueCoding"]
]))
```

A slice whose choice element is narrowed to more than one type yields a single group over the permitted variants, so either variant satisfies it:

```ts
// before: ..., "measuredFinding", ["value"]),
// after:  ..., "measuredFinding", [], [["valueQuantity","valueString"]]),
```

and reports `SlicedChoiceObservation.component[measuredFinding]: at least one of valueQuantity, valueString is required` when neither is present.

## Tests

- `test/assets/profile-sliced-choice/observation-sliced-choice.json` — a generic `Observation` fixture with `component` sliced by pattern on `code`: one slice narrows `value[x]` to `CodeableConcept`, the other to `Quantity | string`. Not derived from any implementation guide.
- `test/api/write-generator/profile-sliced-choice.test.ts` — writes the generated module plus the helper asset to a temp directory and imports it, so the round trip runs through the real generated setter and the real generated validator rather than asserting on emitted text. Covers: a resource written by the profile's own setter passes `Profile.from()`; a matched slice element carrying no variant still fails; the multi-variant group accepts either variant and names both when empty.
- `test/api/write-generator/profile-sliced-choice-python.test.ts` — the corresponding emission assertions for both slices.
- `examples/python-r4-us-core/test_profile_patient.py` — runtime coverage on the US Core race extension, plus direct cases for the helper's multi-variant branch.
