### PR TITLE
TypeSchema: restrict virtual Base root to R4-family references

### DIFF
--- a/src/typeschema/core/transformer.ts
+++ b/src/typeschema/core/transformer.ts
@@ -8,7 +8,7 @@ import assert from "node:assert";
 import type { FHIRSchemaElement } from "@atomic-ehr/fhirschema";
 import { shouldSkipCanonical } from "@root/typeschema/skip-hack";
 import type { CodegenLog } from "@root/utils/log";
-import { isFhirBaseCanonical, type Register } from "@typeschema/register";
+import { isVirtualFhirBaseCanonical, type Register } from "@typeschema/register";
 import {
     concatIdentifiers,
     extractExtensionDeps,
@@ -147,7 +147,9 @@ export function transformFhirSchema(register: Register, fhirSchema: RichFHIRSche
         const baseUrl = register.ensureSpecializationCanonicalUrl(fhirSchema.base);
         const baseFs = register.resolveFs(fhirSchema.package_meta, baseUrl);
         const isVirtualLogicalBase =
-            fhirSchema.kind === "logical" && fhirSchema.derivation === "specialization" && isFhirBaseCanonical(baseUrl);
+            fhirSchema.kind === "logical" &&
+            fhirSchema.derivation === "specialization" &&
+            isVirtualFhirBaseCanonical(fhirSchema.base);
         if (!baseFs && !isVirtualLogicalBase)
             throw new Error(
                 `Base resource not found '${fhirSchema.base}' for <${fhirSchema.url}> from ${packageMetaToFhir(fhirSchema.package_meta)}`,

--- a/src/typeschema/register.ts
+++ b/src/typeschema/register.ts
@@ -21,7 +21,16 @@ import { enrichFHIRSchema, enrichValueSet, packageMetaToFhir, packageMetaToNpm }
 const BARE_RESOURCE_NAME_RE = /^[a-zA-Z0-9]+$/;
 const FHIR_BASE_CANONICAL = "http://hl7.org/fhir/StructureDefinition/Base";
 
-export const isFhirBaseCanonical = (canonical: string): boolean => canonical.split("|")[0] === FHIR_BASE_CANONICAL;
+// `Base` is a virtual root only in the R4 family: R4/R4B ship no
+// StructureDefinition-Base, while R5+ publish it as a physical resource, so a
+// reference explicitly versioned R5+ must resolve like any other base.
+// Takes the raw base reference (bare name or canonical, optionally versioned).
+export const isVirtualFhirBaseCanonical = (ref: string): boolean => {
+    const [name, version] = ref.split("|") as [string, string | undefined];
+    const canonical = BARE_RESOURCE_NAME_RE.test(name) ? `http://hl7.org/fhir/StructureDefinition/${name}` : name;
+    if (canonical !== FHIR_BASE_CANONICAL) return false;
+    return version === undefined || version.startsWith("4.");
+};
 
 export type Register = {
     testAppendFs(fs: FHIRSchema): void;
@@ -242,7 +251,8 @@ export const registerFromManager = async (
         while (fs?.base) {
             const pkg = fs.package_meta;
             const baseUrl = ensureSpecializationCanonicalUrl(fs.base);
-            if (fs.kind === "logical" && fs.derivation === "specialization" && isFhirBaseCanonical(baseUrl)) break;
+            if (fs.kind === "logical" && fs.derivation === "specialization" && isVirtualFhirBaseCanonical(fs.base))
+                break;
             fs = resolveFs(pkg, baseUrl);
             if (fs === undefined)
                 throw new Error(

--- a/test/unit/typeschema/transformer/logical-base.test.ts
+++ b/test/unit/typeschema/transformer/logical-base.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { isVirtualFhirBaseCanonical } from "@root/typeschema/register";
 import { type CanonicalUrl, isLogicalTypeSchema, type Name } from "@root/typeschema/types";
 import type { PFS } from "@typeschema-test/utils";
 import { mkR4Register, mkR5Register, mkTestLogger, registerFsAndMkTs } from "@typeschema-test/utils";
@@ -46,6 +47,27 @@ describe("TypeSchema: logical model specializing FHIR Base (R4, virtual root)", 
         await expect(registerFsAndMkTs(r4, doc, logger)).rejects.toThrow(
             "Base resource not found 'http://example.org/StructureDefinition/MissingParent'",
         );
+    });
+
+    // An explicitly R5+ versioned Base is not virtual: R5 ships a physical
+    // StructureDefinition-Base, so failing to resolve it is a real defect.
+    it("rejects an R5-versioned Base parent", async () => {
+        const doc = mkDocument("http://hl7.org/fhir/StructureDefinition/Base|5.0.0", "DocumentR5Ref");
+        await expect(registerFsAndMkTs(r4, doc, logger)).rejects.toThrow(
+            "Base resource not found 'http://hl7.org/fhir/StructureDefinition/Base|5.0.0'",
+        );
+    });
+});
+
+describe("isVirtualFhirBaseCanonical", () => {
+    it("matches only R4-family Base references", () => {
+        expect(isVirtualFhirBaseCanonical("http://hl7.org/fhir/StructureDefinition/Base")).toBeTrue();
+        expect(isVirtualFhirBaseCanonical("http://hl7.org/fhir/StructureDefinition/Base|4.0.1")).toBeTrue();
+        expect(isVirtualFhirBaseCanonical("http://hl7.org/fhir/StructureDefinition/Base|4.3.0")).toBeTrue();
+        expect(isVirtualFhirBaseCanonical("Base|4.0.1")).toBeTrue();
+        expect(isVirtualFhirBaseCanonical("http://hl7.org/fhir/StructureDefinition/Base|5.0.0")).toBeFalse();
+        expect(isVirtualFhirBaseCanonical("http://hl7.org/fhir/StructureDefinition/Base|6.0.0-ballot3")).toBeFalse();
+        expect(isVirtualFhirBaseCanonical("http://example.org/StructureDefinition/Base|4.0.1")).toBeFalse();
     });
 });
 


### PR DESCRIPTION
Follow-up to #209. The virtual-root fallback keyed on the version-stripped canonical, so it could not tell `Base|4.0.1` from `Base|5.0.0`. `Base` is only virtual in the R4 family — R4/R4B ship no `StructureDefinition-Base`, while R5+ publish it as a physical resource — so an explicitly R5+ versioned reference that fails to resolve is a broken package setup and should stay an error instead of silently producing a rootless model.

- Replace `isFhirBaseCanonical` with `isVirtualFhirBaseCanonical`, which takes the raw base reference (bare name or canonical, optionally versioned) and treats `Base` as virtual only when unversioned or versioned `4.*`.
- Use it at both #209 guard sites: the transformer fallback and the genealogy-walk break in the register.
- Side effect: an R5 logical model referencing `Base|5.0.0` keeps `Base` in its genealogy instead of being skipped.
- Tests: R4 register now rejects a `Base|5.0.0` parent (explicit `rejects.toThrow`, immune to snapshot `-u` refreshes); predicate cases pin the version families (`4.0.1`/`4.3.0`/bare → virtual; `5.0.0`/`6.0.0-ballot3`/non-hl7 canonical → not).

Before, an unresolvable R5-versioned reference fell back to a rootless model:

```ts
// logical specialization with base "http://hl7.org/fhir/StructureDefinition/Base|5.0.0"
// in an R4-only register
transformFhirSchema(...) // => [{ base: undefined, ... }]
```

After, it fails like any other missing base:

```ts
transformFhirSchema(...) // throws: Base resource not found 'http://hl7.org/fhir/StructureDefinition/Base|5.0.0'
```