### PR TITLE
CLI/API: harden the config-driven generate command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,3 +150,51 @@ jobs:
             exit 1
           fi
           echo "type-tree.json exists ($(wc -c < /tmp/test-install/output/type-tree.json) bytes)"
+
+      - name: Run CLI
+        working-directory: /tmp/test-install
+        run: |
+          cat > codegen.json <<'CONFIG'
+          {
+              "version": 1,
+              "builders": [
+                  {
+                      "name": "core",
+                      "fromPackages": [{ "name": "hl7.fhir.r4.core", "version": "4.0.1" }],
+                      "typescript": {},
+                      "outputTo": "./cli-output"
+                  }
+              ]
+          }
+          CONFIG
+
+          run_cli() {
+            if [ "${{ matrix.package-manager }}" == "bun" ]; then
+              bun node_modules/.bin/atomic-codegen "$@"
+            elif [ "${{ matrix.package-manager }}" == "npm" ]; then
+              npx atomic-codegen "$@"
+            else
+              pnpm exec atomic-codegen "$@"
+            fi
+          }
+
+          run_cli --version
+
+          # The command must run exactly once: a duplicate entry point in the
+          # bundle used to execute every CLI command twice under bun/Node 24+.
+          run_cli generate --config ./codegen.json --dry-run | tee plan.txt
+          plans=$(grep -c "Generate plan" plan.txt || true)
+          if [ "$plans" != "1" ]; then
+            echo "expected exactly one generate plan, saw $plans"
+            exit 1
+          fi
+
+          run_cli generate --config ./codegen.json
+
+      - name: Verify CLI output
+        run: |
+          if [ ! -f /tmp/test-install/cli-output/hl7-fhir-r4-core/Patient.ts ]; then
+            echo "CLI generation output missing"
+            exit 1
+          fi
+          echo "CLI output OK ($(find /tmp/test-install/cli-output -name '*.ts' | wc -l) TypeScript files)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ bun run src/cli/index.ts                   # Run CLI in development mode
 
 # CLI Usage
 bun run src/cli/index.ts typeschema generate hl7.fhir.r4.core@4.0.1 -o schemas.ndjson
-bun run src/cli/index.ts generate typescript -i schemas.ndjson -o ./types
+bun run src/cli/index.ts generate --config ./codegen.json
 ```
 
 ## Verification
@@ -69,8 +69,7 @@ FHIR Package → TypeSchema Generator → TypeSchema Format → Code Generators 
 
 ## Configuration
 
-- **Main config**: `atomic-codegen.config.ts` (TypeScript configuration file)
-- **Package config**: Uses `Config` type from `src/config.ts`
+- **CLI config**: JSON file consumed by `atomic-codegen generate --config` (schema and validation in `src/api/generate-config.ts`; relative paths resolve against the config file's directory)
 - **Default packages**: `hl7.fhir.r4.core@4.0.1`
 - **Output dir**: `./generated` by default
 - **Cache**: `.typeschema-cache/` for performance optimization
@@ -326,7 +325,7 @@ Detection uses `mkIsFamilyType(tsIndex)` which checks `schema.typeFamily.resourc
 
 ### Core Logic
 - `src/index.ts` - Main entry point and exports
-- `src/config.ts` - Configuration type definitions
+- `src/api/generate-config.ts` - JSON config schema for the CLI `generate` command
 - `src/api/builder.ts` - APIBuilder implementation
 - `src/typeschema/types.ts` - TypeSchema type definitions
 - `src/typeschema/generator.ts` - TypeSchema generation orchestration

--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ yarn add @atomic-ehr/codegen
     - `bun run generate-types.ts`
     - `pnpm exec tsx generate-types.ts`
 
+Alternatively, drive the same pipeline from a JSON config file, with no script at all:
+
+```json
+{
+    "version": 1,
+    "builders": [
+        {
+            "name": "core",
+            "fromPackages": [{ "name": "hl7.fhir.r4.core", "version": "4.0.1" }],
+            "typescript": {},
+            "outputTo": "./fhir-types"
+        }
+    ]
+}
+```
+
+```bash
+atomic-codegen generate --config ./codegen.json            # run every builder
+atomic-codegen generate --config ./codegen.json --dry-run  # print the plan without generating
+```
+
+Relative paths resolve against the config file's directory, unknown keys are rejected with the full list of problems, and `outputTo` is removed before generation by default (set `"cleanOutput": false` to keep it). A config may hold several builders: each maps to one `APIBuilder` pipeline (`fromPackages`/`fromPackageRefs`/`localTgzPackages`/`localStructureDefinitions` inputs, `typeSchema` transformations, and `typescript`/`python`/`csharp`/`introspection` generators — see `GenerateConfigBuilder` in `src/api/generate-config.ts`). A failed builder does not stop the others, and the run exits non-zero if any failed.
+
 ### Usage Examples
 
 See the [examples/](examples/) directory for working demonstrations:

--- a/src/api/generate-config.ts
+++ b/src/api/generate-config.ts
@@ -55,6 +55,11 @@ export type GenerateConfigBuilder = {
     csharp?: Partial<CSharpGeneratorOptions>;
     /** Output directory, resolved against the config file's directory. */
     outputTo: string;
+    /**
+     * Remove `outputTo` recursively before generation. Defaults to `true`
+     * (APIBuilder's default), so point `outputTo` at a dedicated directory —
+     * never at a directory holding anything else.
+     */
     cleanOutput?: boolean;
     throwException?: boolean;
 };
@@ -695,7 +700,10 @@ export const describeGenerateConfig = (config: GenerateConfig): string => {
         lines.push(`     generators: ${generators.length > 0 ? generators.join(", ") : "none"}`);
         if (builder.typeSchema) lines.push(`     typeSchema: ${Object.keys(builder.typeSchema).join(", ")}`);
         lines.push(`     outputTo: ${builder.outputTo}`);
-        if (builder.cleanOutput !== undefined) lines.push(`     cleanOutput: ${builder.cleanOutput}`);
+        const cleanOutput = builder.cleanOutput ?? true;
+        lines.push(
+            `     cleanOutput: ${cleanOutput}${builder.cleanOutput === undefined ? " (default)" : ""}${cleanOutput ? " — removes outputTo before generation" : ""}`,
+        );
     });
     return lines.join("\n");
 };

--- a/src/api/generate-config.ts
+++ b/src/api/generate-config.ts
@@ -204,6 +204,14 @@ const INPUT_KEYS = ["fromPackages", "fromPackageRefs", "localTgzPackages", "loca
 
 const GENERATOR_KEYS = ["introspection", "typescript", "python", "csharp"] as const;
 
+/** How `b` relates to `a` when both are absolute, normalized directories. */
+const outputOverlap = (a: string, b: string): string | undefined => {
+    if (a === b) return "duplicates";
+    if (b.startsWith(a + Path.sep)) return "is nested inside";
+    if (a.startsWith(b + Path.sep)) return "contains";
+    return undefined;
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -490,6 +498,20 @@ export const parseGenerateConfig = (raw: unknown, configPath: string): GenerateC
         if (seen.has(builder.name))
             report(ctx, `builders[${index}].name`, `duplicate builder name "${builder.name}"; names must be unique`);
         seen.add(builder.name);
+    });
+
+    // outputTo values are absolute by now; overlapping directories would let a
+    // later builder's cleanOutput remove an earlier builder's freshly written files.
+    builders.forEach((builder, index) => {
+        for (const other of builders.slice(0, index)) {
+            const relation = outputOverlap(other.outputTo, builder.outputTo);
+            if (!relation) continue;
+            report(
+                ctx,
+                `builders[${index}].outputTo`,
+                `${relation} the output directory of builder "${other.name}"; output directories must not overlap`,
+            );
+        }
     });
 
     if (ctx.issues.length > 0) throw new GenerateConfigError(ctx.issues);

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -92,11 +92,3 @@ export async function runCLI() {
     const cli = createCLI();
     await cli.parseAsync();
 }
-
-// Run CLI if this file is executed directly
-if (import.meta.main) {
-    runCLI().catch((err) => {
-        cliLogger.error(String(err));
-        process.exit(1);
-    });
-}

--- a/test/unit/api/generate-config.test.ts
+++ b/test/unit/api/generate-config.test.ts
@@ -249,6 +249,34 @@ describe("parseGenerateConfig", () => {
         }
     });
 
+    it("reports a duplicate output directory between builders", () => {
+        const raw = validConfig();
+        raw.builders.push({ ...raw.builders[0]!, name: "other" });
+
+        try {
+            parseGenerateConfig(raw, CONFIG_PATH);
+            throw new Error("expected a GenerateConfigError");
+        } catch (error) {
+            const issue = (error as GenerateConfigError).issues[0]!;
+            expect(issue.path).toBe("builders[1].outputTo");
+            expect(issue.message).toContain('duplicates the output directory of builder "core"');
+        }
+    });
+
+    it("reports an output directory nested inside another builder's output", () => {
+        const raw = validConfig();
+        raw.builders.push({ ...raw.builders[0]!, name: "other", outputTo: "./out/core/nested" });
+
+        try {
+            parseGenerateConfig(raw, CONFIG_PATH);
+            throw new Error("expected a GenerateConfigError");
+        } catch (error) {
+            const issue = (error as GenerateConfigError).issues[0]!;
+            expect(issue.path).toBe("builders[1].outputTo");
+            expect(issue.message).toContain('is nested inside the output directory of builder "core"');
+        }
+    });
+
     it("collects every problem instead of stopping at the first", () => {
         const raw = {
             version: "1",

--- a/test/unit/api/generate-config.test.ts
+++ b/test/unit/api/generate-config.test.ts
@@ -598,5 +598,6 @@ describe("describeGenerateConfig", () => {
         expect(plan).toContain("input: package hl7.fhir.r4.core@4.0.1");
         expect(plan).toContain("generators: typescript");
         expect(plan).toContain(`outputTo: ${Path.join(CONFIG_DIR, "out/core")}`);
+        expect(plan).toContain("cleanOutput: true (default) — removes outputTo before generation");
     });
 });


### PR DESCRIPTION
Follow-up to #211, from its review: three behavior fixes, user documentation, and a CI check that runs the installed CLI under every supported package manager.

## Fixes

- Drop the duplicate CLI entry in `src/cli/commands/index.ts`. Bundling collapsed its `import.meta.main` guard into the entry module, so the published binary executed every command twice under bun and Node ≥ 24.2 — for `generate` that meant two concurrent pipelines racing a `cleanOutput` rmSync over the same directory. `src/cli/index.ts` is the only entry now; verified single-run on the built bundle.
- Reject overlapping builder output directories at parse time (equal, nested, or containing — resolved paths). A later builder's cleanOutput silently wiped an earlier builder's freshly generated files while the run reported success:

```
builders[1].outputTo: is nested inside the output directory of builder "core"; output directories must not overlap
```

- Surface the destructive `cleanOutput` default. It was invisible in `--dry-run` and undocumented; the plan now always states it:

```
before:  outputTo: /work/out/core
after:   outputTo: /work/out/core
         cleanOutput: true (default) — removes outputTo before generation
```

## Docs

- README Quick Start gains the config-driven alternative: JSON example, `--dry-run`, path-resolution and cleanOutput semantics, pointer to `GenerateConfigBuilder`.
- CLAUDE.md loses stale claims: the nonexistent `generate typescript -i schemas.ndjson` form, the phantom `atomic-codegen.config.ts` / `src/config.ts` config story, and the dead key-file pointer.

## CI

- The `package-managers` matrix job now also runs the installed CLI (bun / npm / pnpm): `--version`, `generate --config --dry-run` with an exactly-one-plan assertion (the standing regression test for the double-execution bug — nothing previously executed the built artifact), and a real r4.core generation reusing the job's warm package cache, with output verification. Both runnable legs were simulated locally against a packed tarball.