### PR TITLE
TS: opt-in Node-ESM module specifiers

### DIFF
--- a/src/api/writer-generator/typescript/name.ts
+++ b/src/api/writer-generator/typescript/name.ts
@@ -44,10 +44,6 @@ export const tsModuleFileName = (id: TypeIdentifier): string => {
     return `${tsModuleName(id)}.ts`;
 };
 
-export const tsModulePath = (id: TypeIdentifier): string => {
-    return `${tsPackageDir(id.package)}/${tsModuleName(id)}`;
-};
-
 export const tsNameFromCanonical = (canonical: string | undefined, dropFragment = true) => {
     if (!canonical) return undefined;
     const localName = extractNameFromCanonical(canonical as CanonicalUrl, dropFragment);

--- a/src/api/writer-generator/typescript/profile.ts
+++ b/src/api/writer-generator/typescript/profile.ts
@@ -242,7 +242,7 @@ export const generateProfileIndexFile = (
                 const className = tsProfileClassName(snapshot);
                 const moduleName = tsProfileModuleName(tsIndex, snapshot);
                 if (!exports.has(className)) {
-                    exports.set(className, `export { ${className} } from "./${moduleName}"`);
+                    exports.set(className, `export { ${className} } from "${w.moduleSpecifier(`./${moduleName}`)}"`);
                 }
             }
             for (const exp of [...exports.values()].sort()) {

--- a/src/api/writer-generator/typescript/profile.ts
+++ b/src/api/writer-generator/typescript/profile.ts
@@ -240,13 +240,12 @@ export const generateProfileIndexFile = (
             const exports: Map<string, string> = new Map();
             for (const snapshot of snapshots) {
                 const className = tsProfileClassName(snapshot);
-                const moduleName = tsProfileModuleName(tsIndex, snapshot);
                 if (!exports.has(className)) {
-                    exports.set(className, `export { ${className} } from "${w.moduleSpecifier(`./${moduleName}`)}"`);
+                    exports.set(className, tsProfileModuleName(tsIndex, snapshot));
                 }
             }
-            for (const exp of [...exports.values()].sort()) {
-                w.lineSM(exp);
+            for (const className of [...exports.keys()].sort()) {
+                w.tsExport(`./${exports.get(className)}`, className);
             }
         });
     });
@@ -318,7 +317,7 @@ export const generateProfileImports = (
     const getModulePath = (typeId: TypeIdentifier): string => {
         if (isNestedIdentifier(typeId)) {
             const path = tsNameFromCanonical(typeId.url, true);
-            if (path) return `../../${w.packageDirectory(typeId)}/${pascalCase(path)}`;
+            if (path) return `../../${w.packageDir(typeId)}/${pascalCase(path)}`;
         }
         return `../../${w.modulePath(typeId)}`;
     };

--- a/src/api/writer-generator/typescript/writer.ts
+++ b/src/api/writer-generator/typescript/writer.ts
@@ -1,5 +1,3 @@
-import * as Path from "node:path";
-import { fileURLToPath } from "node:url";
 import { pascalCase, uppercaseFirstLetter } from "@root/api/writer-generator/utils";
 import { Writer, type WriterOptions } from "@root/api/writer-generator/writer";
 import type { PackageTerminology, TerminologyConcept, TerminologyResource } from "@root/typeschema/register";
@@ -22,7 +20,7 @@ import {
     type TypeIdentifier,
     type TypeSchema,
 } from "@root/typeschema/types";
-import { groupByPackages, type TypeSchemaIndex } from "@root/typeschema/utils";
+import type { TypeSchemaIndex } from "@root/typeschema/utils";
 import { resolveGeneratorAsset } from "../assets";
 import {
     tsFieldName,
@@ -93,7 +91,7 @@ const terminologySymbolName = (resource: TerminologyResource): string => {
 const terminologyResourceIdentity = (resource: TerminologyResource): string =>
     `${resource.id ?? ""}\u0000${resource.name ?? ""}`;
 
-const safeTsPackageDir = (source: string): string => {
+const safePackageDir = (source: string): string => {
     const normalized = tsPackageDir(source.replace(PACKAGE_PATH_SEPARATOR_RE, "_"));
     return normalized.replace(INVALID_PACKAGE_DIR_RUN_RE, "-").replace(PACKAGE_DIR_EDGE_RE, "") || "package";
 };
@@ -146,21 +144,25 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         super({ lineWidth: 120, ...options, resolveAssets: options.resolveAssets ?? resolveTsAssets });
     }
 
-    packageDirectory(physical: PackageMeta | TypeIdentifier): string {
+    /** The package's physical output directory: consults the collision-suffix
+     *  map, so it can differ from the logical `tsPackageDir(name)` in name.ts
+     *  (e.g. `hl7-fhir-r4-core--2`). Unprefixed = stateful writer method. */
+    packageDir(physical: PackageMeta | TypeIdentifier): string {
         const pkg = "package" in physical ? { name: physical.package, version: physical.version } : physical;
-        return this.packageDirectories.get(packageMetaToNpm(pkg)) ?? safeTsPackageDir(pkg.name);
+        return this.packageDirectories.get(packageMetaToNpm(pkg)) ?? safePackageDir(pkg.name);
     }
 
+    /** The module's physical position in the output tree: `packageDir/ModuleName`. */
     modulePath(identifier: TypeIdentifier): string {
-        return `${this.packageDirectory(identifier)}/${tsModuleName(identifier)}`;
+        return `${this.packageDir(identifier)}/${tsModuleName(identifier)}`;
     }
 
-    moduleSpecifier(specifier: string): string {
+    private moduleSpecifier(specifier: string): string {
         if (this.opts.moduleSpecifierStyle !== "node-esm" || !specifier.startsWith(".")) return specifier;
         return specifier.endsWith(".js") ? specifier : `${specifier}.js`;
     }
 
-    directorySpecifier(specifier: string): string {
+    private directorySpecifier(specifier: string): string {
         if (this.opts.moduleSpecifierStyle !== "node-esm" || !specifier.startsWith(".")) return specifier;
         return `${specifier}/index.js`;
     }
@@ -202,12 +204,28 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         }
     }
 
+    tsExport(from: string, ...entities: string[]): void;
+    tsExport(from: string, ...args: [...string[], { typeOnly: boolean }]): void;
+    tsExport(from: string, ...rest: (string | { typeOnly: boolean })[]) {
+        const last = rest[rest.length - 1];
+        const typeOnly = typeof last === "object" ? last.typeOnly : false;
+        const entities = (typeof last === "object" ? rest.slice(0, -1) : rest) as string[];
+        const keyword = typeOnly ? "export type" : "export";
+        this.lineSM(`${keyword} { ${entities.join(", ")} } from "${this.moduleSpecifier(from)}"`);
+    }
+
+    /** `export * from` a module, or a directory barrel when `barrel` is set. */
+    tsExportAll(from: string, opts?: { barrel?: boolean }): void {
+        const specifier = opts?.barrel ? this.directorySpecifier(from) : this.moduleSpecifier(from);
+        this.lineSM(`export * from "${specifier}"`);
+    }
+
     generateFhirPackageIndexFile(schemas: TypeSchema[], hasTerminology = false) {
         this.cat("index.ts", () => {
-            if (hasTerminology) this.lineSM(`export * from "${this.moduleSpecifier("./terminology")}"`);
+            if (hasTerminology) this.tsExportAll("./terminology");
             const profiles = schemas.filter(isSnapshotProfileTypeSchema);
             if (profiles.length > 0) {
-                this.lineSM(`export * from "${this.directorySpecifier("./profiles")}"`);
+                this.tsExportAll("./profiles", { barrel: true });
             }
 
             let exports = schemas
@@ -243,12 +261,12 @@ export class TypeScript extends Writer<TypeScriptOptions> {
 
             for (const exp of exports) {
                 this.debugComment(exp.identifier);
-                const specifier = this.moduleSpecifier(`./${exp.tsPackageName}`);
+                const from = `./${exp.tsPackageName}`;
                 if (exp.typeExports.length > 0) {
-                    this.lineSM(`export type { ${exp.typeExports.join(", ")} } from "${specifier}"`);
+                    this.tsExport(from, ...exp.typeExports, { typeOnly: true });
                 }
                 if (exp.valueExports.length > 0) {
-                    this.lineSM(`export { ${exp.valueExports.join(", ")} } from "${specifier}"`);
+                    this.tsExport(from, ...exp.valueExports);
                 }
             }
         });
@@ -297,9 +315,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         if (complexTypeDeps && complexTypeDeps.length > 0) {
             for (const dep of complexTypeDeps) {
                 this.debugComment(dep);
-                this.lineSM(
-                    `export type { ${tsResourceName(dep)} } from "${this.moduleSpecifier(`../${this.modulePath(dep)}`)}"`,
-                );
+                this.tsExport(`../${this.modulePath(dep)}`, tsResourceName(dep), { typeOnly: true });
             }
             this.line();
         }
@@ -601,7 +617,7 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         for (const [identity, { packageMeta: pkg, packageSchemas, terminology: packageTerminology }] of logicalUnits) {
             const directorySource =
                 (identitiesByPackageName.get(pkg.name)?.length ?? 0) > 1 ? packageMetaToNpm(pkg) : pkg.name;
-            const baseDir = safeTsPackageDir(directorySource);
+            const baseDir = safePackageDir(directorySource);
             const units = unitsByBaseDir.get(baseDir) ?? [];
             const schemasByIdentity = new Map(
                 packageSchemas.map((schema) => [JSON.stringify(schema.identifier), schema]),

--- a/src/api/writer-generator/typescript/writer.ts
+++ b/src/api/writer-generator/typescript/writer.ts
@@ -61,6 +61,15 @@ export type TypeScriptOptions = {
      */
     openResourceTypeSet: boolean;
     primitiveTypeExtension: boolean;
+    /** How relative import/export specifiers are written in generated modules.
+     *
+     * - "extensionless" (default): `"./profiles"`, `"../Patient"` — resolved by
+     *   bundlers, TypeScript and Bun.
+     * - "node-esm": explicit file targets (`"./profiles/index.js"`,
+     *   `"../Patient.js"`), so output transpiled to plain `.js` modules under
+     *   `"type": "module"` loads under Node's ESM resolver.
+     */
+    moduleSpecifierStyle?: "extensionless" | "node-esm";
     extensionGetterDefault?: "flat" | "profile" | "raw";
     sliceGetterDefault?: "flat" | "raw";
     terminology?: {
@@ -146,6 +155,16 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         return `${this.packageDirectory(identifier)}/${tsModuleName(identifier)}`;
     }
 
+    moduleSpecifier(specifier: string): string {
+        if (this.opts.moduleSpecifierStyle !== "node-esm" || !specifier.startsWith(".")) return specifier;
+        return specifier.endsWith(".js") ? specifier : `${specifier}.js`;
+    }
+
+    directorySpecifier(specifier: string): string {
+        if (this.opts.moduleSpecifierStyle !== "node-esm" || !specifier.startsWith(".")) return specifier;
+        return `${specifier}/index.js`;
+    }
+
     ifElseChain(branches: { cond: string; body: () => void }[], elseBody?: () => void) {
         branches.forEach((branch, i) => {
             const prefix = i === 0 ? "if" : "} else if";
@@ -170,7 +189,8 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         const typeOnly = typeof last === "object" ? last.typeOnly : false;
         const entities = (typeof last === "object" ? rest.slice(0, -1) : rest) as string[];
         const keyword = typeOnly ? "import type" : "import";
-        const singleLine = `${keyword} { ${entities.join(", ")} } from "${tsPackageName}"`;
+        const specifier = this.moduleSpecifier(tsPackageName);
+        const singleLine = `${keyword} { ${entities.join(", ")} } from "${specifier}"`;
         if (singleLine.length <= (this.opts.lineWidth ?? 120)) {
             this.lineSM(singleLine);
         } else {
@@ -178,16 +198,16 @@ export class TypeScript extends Writer<TypeScriptOptions> {
                 for (const entity of entities) {
                     this.line(`${entity},`);
                 }
-            }, [` from "${tsPackageName}";`]);
+            }, [` from "${specifier}";`]);
         }
     }
 
     generateFhirPackageIndexFile(schemas: TypeSchema[], hasTerminology = false) {
         this.cat("index.ts", () => {
-            if (hasTerminology) this.lineSM(`export * from "./terminology"`);
+            if (hasTerminology) this.lineSM(`export * from "${this.moduleSpecifier("./terminology")}"`);
             const profiles = schemas.filter(isSnapshotProfileTypeSchema);
             if (profiles.length > 0) {
-                this.lineSM(`export * from "./profiles"`);
+                this.lineSM(`export * from "${this.directorySpecifier("./profiles")}"`);
             }
 
             let exports = schemas
@@ -223,11 +243,12 @@ export class TypeScript extends Writer<TypeScriptOptions> {
 
             for (const exp of exports) {
                 this.debugComment(exp.identifier);
+                const specifier = this.moduleSpecifier(`./${exp.tsPackageName}`);
                 if (exp.typeExports.length > 0) {
-                    this.lineSM(`export type { ${exp.typeExports.join(", ")} } from "./${exp.tsPackageName}"`);
+                    this.lineSM(`export type { ${exp.typeExports.join(", ")} } from "${specifier}"`);
                 }
                 if (exp.valueExports.length > 0) {
-                    this.lineSM(`export { ${exp.valueExports.join(", ")} } from "./${exp.tsPackageName}"`);
+                    this.lineSM(`export { ${exp.valueExports.join(", ")} } from "${specifier}"`);
                 }
             }
         });
@@ -276,7 +297,9 @@ export class TypeScript extends Writer<TypeScriptOptions> {
         if (complexTypeDeps && complexTypeDeps.length > 0) {
             for (const dep of complexTypeDeps) {
                 this.debugComment(dep);
-                this.lineSM(`export type { ${tsResourceName(dep)} } from "${`../${this.modulePath(dep)}`}"`);
+                this.lineSM(
+                    `export type { ${tsResourceName(dep)} } from "${this.moduleSpecifier(`../${this.modulePath(dep)}`)}"`,
+                );
             }
             this.line();
         }

--- a/test/api/write-generator/__snapshots__/module-specifier-style.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/module-specifier-style.test.ts.snap
@@ -1,0 +1,19 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`module specifier styles node-esm package index pinned 1`] = `
+"export * from "./profiles/index.js";
+"
+`;
+
+exports[`module specifier styles node-esm profiles barrel pinned 1`] = `
+"export { MinimalRequiredExtensionProfile } from "./Extension_MinimalRequiredExtension.js";
+export { PraxisProposalProvenanceProfile } from "./Provenance_PraxisProposalProvenance.js";
+"
+`;
+
+exports[`module specifier styles node-esm profile module imports pinned 1`] = `
+"import type { CodeableConcept } from "../../hl7-fhir-r4-core/CodeableConcept.js";
+import type { Provenance, ProvenanceAgent } from "../../hl7-fhir-r4-core/Provenance.js";
+import type { Reference } from "../../hl7-fhir-r4-core/Reference.js";
+} from "../../profile-helpers.js";"
+`;

--- a/test/api/write-generator/module-specifier-style.test.ts
+++ b/test/api/write-generator/module-specifier-style.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as Path from "node:path";
+import { APIBuilder } from "@root/api/builder";
+import type { TypeScriptOptions } from "@root/api/writer-generator/typescript/writer";
+import { mkSilentLogger } from "@typeschema-test/utils";
+
+const FIXTURE_PATH = Path.join(__dirname, "../../assets/profile-inherited-required");
+const PACKAGE_DIR = "cognovis-test-praxis";
+
+const generate = async (style?: TypeScriptOptions["moduleSpecifierStyle"]) => {
+    const result = await new APIBuilder({ logger: mkSilentLogger() })
+        .localStructureDefinitions({
+            package: { name: "cognovis.test.praxis", version: "0.0.1" },
+            path: FIXTURE_PATH,
+            dependencies: [{ name: "hl7.fhir.r4.core", version: "4.0.1" }],
+        })
+        .typescript({
+            inMemoryOnly: true,
+            generateProfile: true,
+            withDebugComment: false,
+            ...(style ? { moduleSpecifierStyle: style } : {}),
+        })
+        .generate();
+    if (!result.success) throw new Error("generation failed");
+    return result.filesGenerated.typescript ?? {};
+};
+
+const relativeSpecifiers = (files: Record<string, string>): string[] =>
+    Object.values(files).flatMap((source) =>
+        [...source.matchAll(/ from "(\.[^"]*)"/g)].map(([, specifier]) => specifier ?? ""),
+    );
+
+const fileBySuffix = (files: Record<string, string>, suffix: string): string => {
+    const found = Object.entries(files).find(([path]) => path.endsWith(suffix));
+    if (!found) throw new Error(`No generated file matching '*${suffix}'`);
+    return found[1];
+};
+
+describe("module specifier styles", async () => {
+    const extensionless = await generate();
+    const nodeEsm = await generate("node-esm");
+
+    it("defaults to extensionless specifiers", () => {
+        const withExtension = relativeSpecifiers(extensionless).filter((specifier) => specifier.endsWith(".js"));
+        expect(withExtension).toEqual([]);
+    });
+
+    it("node-esm style leaves no extensionless relative specifier anywhere", () => {
+        const offenders = relativeSpecifiers(nodeEsm).filter((specifier) => !specifier.endsWith(".js"));
+        expect(offenders).toEqual([]);
+    });
+
+    it("both styles generate the same file set", () => {
+        expect(Object.keys(nodeEsm).sort()).toEqual(Object.keys(extensionless).sort());
+    });
+
+    it("node-esm package index pinned", () => {
+        expect(fileBySuffix(nodeEsm, `${PACKAGE_DIR}/index.ts`)).toMatchSnapshot();
+    });
+
+    it("node-esm profiles barrel pinned", () => {
+        expect(fileBySuffix(nodeEsm, `${PACKAGE_DIR}/profiles/index.ts`)).toMatchSnapshot();
+    });
+
+    it("node-esm profile module imports pinned", () => {
+        const module = fileBySuffix(nodeEsm, "profiles/Provenance_PraxisProposalProvenance.ts");
+        const imports = module
+            .split("\n")
+            .filter((line) => line.includes(' from "'))
+            .join("\n");
+        expect(imports).toMatchSnapshot();
+    });
+});
+
+/**
+ * The style exists because Node's ESM resolver takes relative specifiers
+ * literally: no extension appending, no directory index. A projection
+ * transpiled to plain `.js` under `"type": "module"` only loads when every
+ * relative specifier names its file — the check runs the real `node` binary,
+ * where Bun's more forgiving resolver can't mask the defect.
+ */
+describe("node-esm style under the Node ESM resolver", async () => {
+    const dir = await fs.mkdtemp(Path.join(os.tmpdir(), "module-specifier-style-"));
+    await new APIBuilder({ logger: mkSilentLogger() })
+        .localStructureDefinitions({
+            package: { name: "cognovis.test.praxis", version: "0.0.1" },
+            path: FIXTURE_PATH,
+            dependencies: [{ name: "hl7.fhir.r4.core", version: "4.0.1" }],
+        })
+        .typescript({ generateProfile: true, withDebugComment: false, moduleSpecifierStyle: "node-esm" })
+        .outputTo(dir)
+        .generate();
+
+    // Transpiling only erases types — it rewrites no import specifier — so
+    // what Node resolves here is exactly what the generator emitted.
+    const transpiler = new Bun.Transpiler({ loader: "ts" });
+    for (const entry of await fs.readdir(dir, { recursive: true })) {
+        if (!entry.endsWith(".ts")) continue;
+        const source = Path.join(dir, entry);
+        await fs.writeFile(source.replace(/\.ts$/, ".js"), transpiler.transformSync(await fs.readFile(source, "utf8")));
+    }
+    await fs.writeFile(Path.join(dir, "package.json"), JSON.stringify({ type: "module" }));
+
+    it("resolves the whole chain from the package index", async () => {
+        const url = new URL(`file://${Path.join(dir, `${PACKAGE_DIR}/index.js`)}`).href;
+        const script = `const m = await import(${JSON.stringify(url)}); if (typeof m.PraxisProposalProvenanceProfile !== "function") { console.error("missing export"); process.exit(3); }`;
+        const proc = Bun.spawn(["node", "--input-type=module", "-e", script], { stdout: "pipe", stderr: "pipe" });
+        const stderr = await new Response(proc.stderr).text();
+
+        expect(stderr).not.toContain("ERR_MODULE_NOT_FOUND");
+        expect(stderr).not.toContain("ERR_UNSUPPORTED_DIR_IMPORT");
+        expect(await proc.exited).toBe(0);
+    });
+});


### PR DESCRIPTION
Inspired by #213 (thanks @sussdorff for the diagnosis and the Node-resolver runtime check): Node's ESM resolver takes relative specifiers literally — no extension appending, no directory index — so a projection transpiled to plain `.js` modules under `"type": "module"` fails with `ERR_MODULE_NOT_FOUND` / `ERR_UNSUPPORTED_DIR_IMPORT`.

Where this differs from #213: the style is a **configurable option instead of a global flip**, so the default output stays byte-identical (verified: regenerating the committed example produces zero drift) and no committed example or snapshot churns.

```ts
// default — unchanged output
.typescript({ ... })

// opt in for projections published as plain ESM .js
.typescript({ ..., moduleSpecifierStyle: "node-esm" })
```

Generated output under `"node-esm"`:

```ts
// before (default style)
export * from "./profiles";
import type { Provenance } from "../../hl7-fhir-r4-core/Provenance";

// after (moduleSpecifierStyle: "node-esm")
export * from "./profiles/index.js";
import type { Provenance } from "../../hl7-fhir-r4-core/Provenance.js";
```

- `moduleSpecifierStyle?: "extensionless" | "node-esm"` on `TypeScriptOptions`, default `"extensionless"`.
- #213's `tsModuleSpecifier(specifier, target)` split into two functions — `tsEsmModuleSpecifier` and `tsEsmDirectorySpecifier` — with thin style-gating methods on the writer (`moduleSpecifier`/`directorySpecifier`).
- All seven relative-specifier emission sites routed through the gate, including `export * from "./terminology"` (added by #210 after #213 was written, so #213 missed it).
- Tests: snapshots pin both styles (package index, profiles barrel, a profile module's imports under `node-esm`; default asserted extensionless), plus #213's real-`node` runtime check adapted to the option — transpile the projection to `.js`, import through the whole chain under Node.

## Naming refactor (byte-identical output, verified by regenerating the example)

The specifier work triggered a review of the whole path/name helper family, folded in here as a `ref:` commit:

- Purity rule: pure logical functions in `name.ts` keep the `ts` prefix; stateful writer methods are unprefixed — `packageDirectory` becomes `packageDir` (physical, collision-suffix aware; can disagree with the logical `tsPackageDir(name)`), `modulePath` stays, module-local `safeTsPackageDir` becomes `safePackageDir`.
- Dead free `tsModulePath` removed (no callers since #210) and the three unused imports left by the #210 merge resolution dropped.
- New `tsExport` / `tsExportAll` emitters mirror `tsImport`, so every export-from line goes through one call and `moduleSpecifier`/`directorySpecifier` become private — the style is an implementation detail of the emitters, and a future emission site can't forget to apply it.

Supersedes #213 if we agree on the opt-in approach.
