### PR TITLE
TS: Accept concrete references for abstract Resource targets

### DIFF
--- a/assets/api/writer-generator/typescript/profile-helpers.ts
+++ b/assets/api/writer-generator/typescript/profile-helpers.ts
@@ -507,7 +507,9 @@ export const validateEnum = (res: object, profileName: string, field: string, al
 /**
  * Checks that a Reference field points to one of the `allowed` resource
  * types.  Extracts the type from the `reference` string (the part before
- * the first `/`).  Skips validation when the field or reference is absent.
+ * the first `/`).  The abstract `Resource` target accepts any concrete
+ * resource type; explicit targets remain exact restrictions.  Skips
+ * validation when the field or reference is absent.
  */
 export const validateReference = (res: object, profileName: string, field: string, allowed: string[]): string[] => {
     const value = (res as Record<string, unknown>)[field];
@@ -517,7 +519,7 @@ export const validateReference = (res: object, profileName: string, field: strin
     const slashIdx = ref.indexOf("/");
     if (slashIdx === -1) return [];
     const refType = ref.slice(0, slashIdx);
-    return allowed.includes(refType)
+    return allowed.includes("Resource") || allowed.includes(refType)
         ? []
         : [`${profileName}: field '${field}' references '${refType}' but only ${allowed.join(", ")} are allowed`];
 };

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
     "rollup": ">=4.59.0",
-    "smol-toml": ">=1.6.1",
+    "smol-toml": ">=1.7.1",
   },
   "packages": {
     "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.24", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-3h+uGf3qqxNX2oClVx+Fz1NZ2Jm2h2dXKrbhA77gURmX5TUYYQKxdTh58a7N/tteLLsig5fW8q41wfeUqy7GdQ=="],
@@ -408,7 +408,7 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 

--- a/examples/typescript-r4-us-core/fhir-types/profile-helpers.ts
+++ b/examples/typescript-r4-us-core/fhir-types/profile-helpers.ts
@@ -507,7 +507,9 @@ export const validateEnum = (res: object, profileName: string, field: string, al
 /**
  * Checks that a Reference field points to one of the `allowed` resource
  * types.  Extracts the type from the `reference` string (the part before
- * the first `/`).  Skips validation when the field or reference is absent.
+ * the first `/`).  The abstract `Resource` target accepts any concrete
+ * resource type; explicit targets remain exact restrictions.  Skips
+ * validation when the field or reference is absent.
  */
 export const validateReference = (res: object, profileName: string, field: string, allowed: string[]): string[] => {
     const value = (res as Record<string, unknown>)[field];
@@ -517,7 +519,7 @@ export const validateReference = (res: object, profileName: string, field: strin
     const slashIdx = ref.indexOf("/");
     if (slashIdx === -1) return [];
     const refType = ref.slice(0, slashIdx);
-    return allowed.includes(refType)
+    return allowed.includes("Resource") || allowed.includes(refType)
         ? []
         : [`${profileName}: field '${field}' references '${refType}' but only ${allowed.join(", ")} are allowed`];
 };

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "overrides": {
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
-    "smol-toml": ">=1.6.1",
+    "smol-toml": ">=1.7.1",
     "brace-expansion": "^5.0.9",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"

--- a/test/unit/api/writer-generator/typescript/profile-helpers.test.ts
+++ b/test/unit/api/writer-generator/typescript/profile-helpers.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { validateReference } from "../../../../../assets/api/writer-generator/typescript/profile-helpers";
+
+test("validateReference accepts an Organization for a Resource target", () => {
+    expect(
+        validateReference({ subject: { reference: "Organization/synthetic" } }, "Audit", "subject", ["Resource"]),
+    ).toEqual([]);
+});
+
+test("validateReference accepts a Practitioner for a Resource target", () => {
+    expect(
+        validateReference({ subject: { reference: "Practitioner/synthetic" } }, "Audit", "subject", ["Resource"]),
+    ).toEqual([]);
+});
+
+test("validateReference accepts a Patient for a Patient target", () => {
+    expect(validateReference({ subject: { reference: "Patient/synthetic" } }, "Audit", "subject", ["Patient"])).toEqual(
+        [],
+    );
+});
+
+test("validateReference rejects an Organization for a Patient target", () => {
+    expect(
+        validateReference({ subject: { reference: "Organization/synthetic" } }, "Audit", "subject", ["Patient"]),
+    ).toHaveLength(1);
+});


### PR DESCRIPTION
Our downstream FHIR SDK validates generated profiles when accepting resources. During a contract audit with synthetic examples, references to `Organization` and `Practitioner` were rejected when a profile declared the abstract target `Resource`: the helper compared the concrete resource name with the literal string `Resource`.

This lets us accept those valid references through the generated validation path without consumer-specific exceptions. It also benefits other applications using profiles that allow a general resource reference, while preserving explicit restrictions such as Patient-only targets.

- Accept concrete resource references when the allowed target is the abstract `Resource` type.
- Preserve exact restrictions for explicit targets such as `Patient`.
- Add runtime regressions and refresh the checked-in TypeScript profile helper.
- Raise the `smol-toml` override to `>=1.7.1` and lock `1.8.0` to fix the shared security audit failure (GHSA-7w5x-hrqm-74c2).

Concrete references now satisfy abstract `Resource` targets:

```ts
const resource = { subject: { reference: "Organization/synthetic" } };
validateReference(resource, "Audit", "subject", ["Resource"]);
// Before: ["Audit: field 'subject' references 'Organization' but only Resource are allowed"]
// After: []
```

Explicit target restrictions continue to reject other resource types:

```ts
validateReference(resource, "Audit", "subject", ["Patient"]);
// Before and after: ["Audit: field 'subject' references 'Organization' but only Patient are allowed"]
```
