### PR TITLE
TS: Validate optional and repeating profile constraints correctly

### DIFF
--- a/assets/api/writer-generator/typescript/profile-helpers.ts
+++ b/assets/api/writer-generator/typescript/profile-helpers.ts
@@ -369,9 +369,10 @@ export const validateExcluded = (res: object, profileName: string, field: string
         : [];
 };
 
-/** Checks that `field` structurally contains the expected fixed value. */
+/** Checks that a present `field` structurally contains the expected fixed value. */
 export const validateFixedValue = (res: object, profileName: string, field: string, expected: unknown): string[] => {
-    return matchesValue((res as Record<string, unknown>)[field], expected)
+    const value = (res as Record<string, unknown>)[field];
+    return value === undefined || matchesValue(value, expected)
         ? []
         : [`${profileName}: field '${field}' does not match expected fixed value`];
 };

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
     "rollup": ">=4.59.0",
-    "smol-toml": ">=1.6.1",
+    "smol-toml": ">=1.7.1",
   },
   "packages": {
     "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.24", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-3h+uGf3qqxNX2oClVx+Fz1NZ2Jm2h2dXKrbhA77gURmX5TUYYQKxdTh58a7N/tteLLsig5fW8q41wfeUqy7GdQ=="],
@@ -408,7 +408,7 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 

--- a/examples/on-the-fly/norge-r4/__snapshots__/kjernejournal-profiles.test.ts.snap
+++ b/examples/on-the-fly/norge-r4/__snapshots__/kjernejournal-profiles.test.ts.snap
@@ -4315,7 +4315,7 @@ export class KjPractitionerRoleProfile {
                 ...validateRequired(res, profileName, "organization"),
                 ...validateReference(res, profileName, "organization", ["Organization"]),
                 ...validateRequired(res, profileName, "code"),
-                ...validatePatternValue(res, profileName, "code", {"coding":[{"system":"http://nhn.no/kj/fhir/CodeSystem/CategoriesOfHealthProfessionals"}]}),
+                ...validatePatternValue(res, profileName, "code", [{"coding":[{"system":"http://nhn.no/kj/fhir/CodeSystem/CategoriesOfHealthProfessionals"}]}]),
                 ...validateReference(res, profileName, "location", ["Location"]),
                 ...validateReference(res, profileName, "healthcareService", ["HealthcareService"]),
                 ...validateReference(res, profileName, "endpoint", ["Endpoint"]),

--- a/examples/typescript-r4-us-core/fhir-types/profile-helpers.ts
+++ b/examples/typescript-r4-us-core/fhir-types/profile-helpers.ts
@@ -369,9 +369,10 @@ export const validateExcluded = (res: object, profileName: string, field: string
         : [];
 };
 
-/** Checks that `field` structurally contains the expected fixed value. */
+/** Checks that a present `field` structurally contains the expected fixed value. */
 export const validateFixedValue = (res: object, profileName: string, field: string, expected: unknown): string[] => {
-    return matchesValue((res as Record<string, unknown>)[field], expected)
+    const value = (res as Record<string, unknown>)[field];
+    return value === undefined || matchesValue(value, expected)
         ? []
         : [`${profileName}: field '${field}' does not match expected fixed value`];
 };

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "overrides": {
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
-    "smol-toml": ">=1.6.1",
+    "smol-toml": ">=1.7.1",
     "brace-expansion": "^5.0.9",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"

--- a/src/api/writer-generator/typescript/profile-validation.ts
+++ b/src/api/writer-generator/typescript/profile-validation.ts
@@ -66,10 +66,11 @@ export const collectRegularFieldValidation = (
     if (field.required) errors.push(`...validateRequired(res, profileName, ${JSON.stringify(name)})`);
 
     if (field.valueConstraint) {
-        const valueExpr =
+        const constrainedValueExpr =
             canonicalUrlExpr && name === "url" && field.valueConstraint.value === canonicalUrlExpr.url
                 ? canonicalUrlExpr.expr
                 : JSON.stringify(field.valueConstraint.value);
+        const valueExpr = field.array ? `[${constrainedValueExpr}]` : constrainedValueExpr;
         const fn = field.valueConstraint.validateOnly ? "validatePatternValue" : "validateFixedValue";
         errors.push(`...${fn}(res, profileName, ${JSON.stringify(name)}, ${valueExpr})`);
     }

--- a/test/api/write-generator/profile-optional-constraint.test.ts
+++ b/test/api/write-generator/profile-optional-constraint.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as Path from "node:path";
+import { APIBuilder } from "@root/api/builder";
+import { mkSilentLogger } from "@typeschema-test/utils";
+
+describe("Optional constrained profile fields", async () => {
+    const result = await new APIBuilder({ logger: mkSilentLogger() })
+        .localStructureDefinitions({
+            package: { name: "example.test.optionalconstraint", version: "0.1.0" },
+            path: Path.join(__dirname, "../../assets/profile-optional-constraint"),
+            dependencies: [{ name: "hl7.fhir.r4.core", version: "4.0.1" }],
+        })
+        .typescript({ inMemoryOnly: true, generateProfile: true, withDebugComment: false })
+        .generate();
+    if (!result.success) throw new Error("Profile generation failed");
+    const files = result.filesGenerated.typescript ?? {};
+    const profilePath = Object.keys(files).find((key) => key.includes("ServiceRequest_OptionalCategoryServiceRequest"));
+    if (!profilePath) throw new Error("Generated ServiceRequest profile is missing");
+
+    const directory = await fs.mkdtemp(Path.join(os.tmpdir(), "optional-profile-constraint-"));
+    afterAll(() => fs.rm(directory, { recursive: true, force: true }));
+    for (const [relativePath, content] of Object.entries(files)) {
+        const destination = Path.join(directory, relativePath);
+        await fs.mkdir(Path.dirname(destination), { recursive: true });
+        await fs.writeFile(destination, content);
+    }
+    const { OptionalCategoryServiceRequestProfile: profile } = await import(Path.join(directory, profilePath));
+    const resource = {
+        resourceType: "ServiceRequest",
+        meta: { profile: ["http://example.test/StructureDefinition/optional-category-service-request"] },
+        status: "active",
+        intent: "order",
+        subject: { reference: "Patient/example" },
+    };
+
+    it("accepts an omitted optional pattern field through the generated parser", () => {
+        expect(() => profile.from(resource)).not.toThrow();
+    });
+
+    it("accepts a present matching optional fixed value", () => {
+        expect(() => profile.from({ ...resource, doNotPerform: false })).not.toThrow();
+    });
+
+    it("rejects a present mismatching optional fixed value", () => {
+        expect(() => profile.from({ ...resource, doNotPerform: true })).toThrow(
+            "field 'doNotPerform' does not match expected fixed value",
+        );
+    });
+
+    it("accepts a present matching repeating pattern", () => {
+        const category = [{ coding: [{ system: "http://example.test/category", code: "example" }] }];
+        expect(() => profile.from({ ...resource, category })).not.toThrow();
+    });
+
+    it("parses its own factory output with the populated repeating pattern", () => {
+        const created = profile.createResource({ status: "active", subject: { reference: "Patient/example" } });
+        expect(created.category).toEqual([{ coding: [{ system: "http://example.test/category", code: "example" }] }]);
+        expect(() => profile.from(created)).not.toThrow();
+    });
+
+    it("still requires a constrained required field", () => {
+        const { intent: _intent, ...withoutIntent } = resource;
+        expect(() => profile.from(withoutIntent)).toThrow("required field 'intent' is missing");
+    });
+
+    it.each([null, false, 0, "", [{ coding: [{ system: "http://example.test/category", code: "other" }] }]])(
+        "rejects a present mismatching optional pattern: %j",
+        (category) => {
+            expect(() => profile.from({ ...resource, category })).toThrow(
+                "field 'category' does not match expected fixed value",
+            );
+        },
+    );
+
+    it("rejects a present mismatching required fixed value", () => {
+        expect(() => profile.from({ ...resource, intent: "plan" })).toThrow(
+            "field 'intent' does not match expected fixed value",
+        );
+    });
+});

--- a/test/assets/profile-optional-constraint/service-request.json
+++ b/test/assets/profile-optional-constraint/service-request.json
@@ -1,0 +1,40 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "optional-category-service-request",
+  "url": "http://example.test/StructureDefinition/optional-category-service-request",
+  "version": "0.1.0",
+  "name": "OptionalCategoryServiceRequest",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "ServiceRequest",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "ServiceRequest.doNotPerform",
+        "path": "ServiceRequest.doNotPerform",
+        "min": 0,
+        "fixedBoolean": false
+      },
+      {
+        "id": "ServiceRequest.category",
+        "path": "ServiceRequest.category",
+        "min": 0,
+        "max": "*",
+        "mustSupport": true,
+        "patternCodeableConcept": {
+          "coding": [{ "system": "http://example.test/category", "code": "example" }]
+        }
+      },
+      {
+        "id": "ServiceRequest.intent",
+        "path": "ServiceRequest.intent",
+        "min": 1,
+        "fixedCode": "order"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
During our downstream SDK migration, a generated dental ServiceRequest profile rejected a synthetic resource with no `category`, even though the profile declares `category` as optional and repeating (`min: 0`, `max: *`) with a value pattern. A matching populated category could also fail because validation compared its array with an unwrapped constraint object; factory output therefore did not reliably round-trip through the generated parser.

We need the generated validator to follow the profile's cardinality and value constraints without relaxing the profile or adding validation bypasses in our application. Other users of optional or repeating constrained fields get the same benefit: permitted absence is accepted, matching values parse, and required fields and present mismatches remain checked. This preserves the existing content-matching semantics rather than introducing a broader fixed/pattern redesign.

- Allow omitted optional fixed and pattern fields while retaining required-field checks and rejecting present mismatches.
- Represent repeating constraint values as arrays in generated validation.
- Cover optional fixed values, repeating patterns, and factory-to-parser round trips; update the generated runtime helper.
- Raise the `smol-toml` override to `>=1.7.1` and lock `1.8.0` to fix the shared security audit failure (GHSA-7w5x-hrqm-74c2).

Optional constrained fields can now be omitted without a validation error.

```typescript
const resource = {
  resourceType: "ServiceRequest",
  meta: { profile: [OptionalCategoryServiceRequestProfile.canonicalUrl] },
  status: "active",
  intent: "order",
  subject: { reference: "Patient/example" },
};
// Before: throws because the optional constrained category is absent.
// After: parses successfully.
OptionalCategoryServiceRequestProfile.from(resource);
```

Repeating patterns now use the same array shape as the resource and factory output.

```typescript
// Before
validateFixedValue(res, profileName, "category", {
  coding: [{ system: "http://example.test/category", code: "example" }],
});
// After
validateFixedValue(res, profileName, "category", [{
  coding: [{ system: "http://example.test/category", code: "example" }],
}]);
```
