### PR TITLE
CLI/API: Expose TypeScript module and terminology options in JSON config

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,23 @@ atomic-codegen generate --config ./codegen.json --dry-run  # print the plan with
 
 Relative paths resolve against the config file's directory, unknown keys are rejected with the full list of problems, and `outputTo` is removed before generation by default (set `"cleanOutput": false` to keep it). A config may hold several builders: each maps to one `APIBuilder` pipeline (`fromPackages`/`fromPackageRefs`/`localTgzPackages`/`localStructureDefinitions` inputs, `typeSchema` transformations, and `typescript`/`python`/`csharp`/`introspection` generators — see `GenerateConfigBuilder` in `src/api/generate-config.ts`). A failed builder does not stop the others, and the run exits non-zero if any failed.
 
+The JSON `typescript` options also accept `moduleSpecifierStyle` (`"extensionless"` or `"node-esm"`) and `terminology`. For Node ESM imports and terminology output restricted to selected packages, replace `"typescript": {}` with:
+
+```json
+"typescript": {
+    "moduleSpecifierStyle": "node-esm",
+    "terminology": {
+        "enabled": true,
+        "packages": ["hl7.fhir.r4.core@4.0.1"],
+        "packageVerification": {
+            "hl7.fhir.r4.core@4.0.1": "registry-integrity"
+        }
+    }
+}
+```
+
+Terminology options require a boolean `enabled`, an array of strings for `packages`, and string values in `packageVerification` when supplied. Unknown nested keys and invalid values are reported with their full configuration paths.
+
 ### Usage Examples
 
 See the [examples/](examples/) directory for working demonstrations:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The JSON `typescript` options also accept `moduleSpecifierStyle` (`"extensionles
 }
 ```
 
-Terminology options require a boolean `enabled`, an array of strings for `packages`, and string values in `packageVerification` when supplied. Unknown nested keys and invalid values are reported with their full configuration paths.
+All terminology fields are optional. When supplied, `enabled` must be a boolean, `packages` must be an array of strings, and `packageVerification` must contain string values. Unknown nested keys and invalid values are reported with their full configuration paths.
 
 ### Usage Examples
 

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
     "rollup": ">=4.59.0",
-    "smol-toml": ">=1.6.1",
+    "smol-toml": ">=1.7.1",
   },
   "packages": {
     "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.24", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-3h+uGf3qqxNX2oClVx+Fz1NZ2Jm2h2dXKrbhA77gURmX5TUYYQKxdTh58a7N/tteLLsig5fW8q41wfeUqy7GdQ=="],
@@ -408,7 +408,7 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "overrides": {
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
-    "smol-toml": ">=1.6.1",
+    "smol-toml": ">=1.7.1",
     "brace-expansion": "^5.0.9",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"

--- a/src/api/generate-config.ts
+++ b/src/api/generate-config.ts
@@ -177,9 +177,13 @@ const TYPESCRIPT_KEYS = [
     "lineWidth",
     "openResourceTypeSet",
     "primitiveTypeExtension",
+    "moduleSpecifierStyle",
     "extensionGetterDefault",
     "sliceGetterDefault",
+    "terminology",
 ] as const satisfies readonly (keyof TypeScriptOptions)[];
+
+const TERMINOLOGY_KEYS = ["enabled", "packages", "packageVerification"] as const;
 
 const PYTHON_KEYS = [
     ...WRITER_KEYS,
@@ -363,6 +367,42 @@ const readGeneratorOptions = <T>(ctx: Ctx, value: unknown, path: string, allowed
     return record as T;
 };
 
+const readTypeScriptOptions = (ctx: Ctx, value: unknown, path: string): Partial<TypeScriptOptions> | undefined => {
+    const record = readRecord(ctx, value, path);
+    if (!record) return undefined;
+    checkKnownKeys(ctx, record, TYPESCRIPT_KEYS, path);
+    const moduleSpecifierStylePath = childPath(path, "moduleSpecifierStyle");
+    const moduleSpecifierStyle =
+        record.moduleSpecifierStyle === undefined
+            ? undefined
+            : readString(ctx, record.moduleSpecifierStyle, moduleSpecifierStylePath);
+    if (moduleSpecifierStyle !== undefined && !["extensionless", "node-esm"].includes(moduleSpecifierStyle)) {
+        report(ctx, moduleSpecifierStylePath, "expected one of: extensionless, node-esm");
+    }
+    if (record.terminology === undefined) return record as Partial<TypeScriptOptions>;
+
+    const terminologyPath = childPath(path, "terminology");
+    const terminology = readRecord(ctx, record.terminology, terminologyPath);
+    if (!terminology) return record as Partial<TypeScriptOptions>;
+    checkKnownKeys(ctx, terminology, TERMINOLOGY_KEYS, terminologyPath);
+    const enabled =
+        terminology.enabled === undefined
+            ? undefined
+            : readBoolean(ctx, terminology.enabled, childPath(terminologyPath, "enabled"));
+    const packages =
+        terminology.packages === undefined
+            ? undefined
+            : readStringArray(ctx, terminology.packages, childPath(terminologyPath, "packages"));
+    const packageVerification =
+        terminology.packageVerification === undefined
+            ? undefined
+            : readStringMap(ctx, terminology.packageVerification, childPath(terminologyPath, "packageVerification"));
+    return {
+        ...record,
+        terminology: { enabled, packages, packageVerification },
+    } as Partial<TypeScriptOptions>;
+};
+
 const readBuilder = (ctx: Ctx, value: unknown, path: string): GenerateConfigBuilder | undefined => {
     const record = readRecord(ctx, value, path);
     if (!record) return undefined;
@@ -399,12 +439,7 @@ const readBuilder = (ctx: Ctx, value: unknown, path: string): GenerateConfigBuil
             INTROSPECTION_KEYS,
         );
     if (record.typescript !== undefined)
-        builder.typescript = readGeneratorOptions(
-            ctx,
-            record.typescript,
-            childPath(path, "typescript"),
-            TYPESCRIPT_KEYS,
-        );
+        builder.typescript = readTypeScriptOptions(ctx, record.typescript, childPath(path, "typescript"));
     if (record.python !== undefined)
         builder.python = readGeneratorOptions(ctx, record.python, childPath(path, "python"), PYTHON_KEYS);
     if (record.csharp !== undefined)

--- a/test/unit/api/generate-config.test.ts
+++ b/test/unit/api/generate-config.test.ts
@@ -108,6 +108,78 @@ describe("parseGenerateConfig", () => {
         expect(config.builders[0]!.name).toBe("core");
     });
 
+    it("accepts package verification provenance for TypeScript terminology", () => {
+        const raw = validConfig();
+        raw.builders[0]!.typescript = {
+            terminology: {
+                enabled: true,
+                packageVerification: {
+                    "hl7.fhir.r4.core@4.0.1": "registry-integrity",
+                    "bfarm.terminologien.icd10gm@2026.0.0": "unverifiable",
+                },
+            },
+        };
+
+        const config = parseGenerateConfig(raw, CONFIG_PATH);
+
+        expect(config.builders[0]!.typescript).toEqual(raw.builders[0]!.typescript);
+    });
+
+    it("rejects invalid TypeScript module and terminology option values", () => {
+        const raw = validConfig();
+        raw.builders[0]!.typescript = {
+            moduleSpecifierStyle: "commonjs",
+            terminology: { enabled: true, packages: ["fixture.ig@1.2.3", 42] },
+        };
+
+        try {
+            parseGenerateConfig(raw, CONFIG_PATH);
+            throw new Error("expected a GenerateConfigError");
+        } catch (error) {
+            const issues = (error as GenerateConfigError).issues;
+            expect(issues.map((issue) => issue.path)).toEqual([
+                "builders[0].typescript.moduleSpecifierStyle",
+                "builders[0].typescript.terminology.packages[1]",
+            ]);
+            expect(issues[0]!.message).toContain("extensionless, node-esm");
+            expect(issues[1]!.message).toContain("expected a string");
+        }
+    });
+
+    it.each(["extensionless", "node-esm"])("accepts the %s TypeScript module style", (moduleSpecifierStyle) => {
+        const raw = validConfig();
+        raw.builders[0]!.typescript = { moduleSpecifierStyle };
+
+        expect(parseGenerateConfig(raw, CONFIG_PATH).builders[0]!.typescript).toEqual({ moduleSpecifierStyle });
+    });
+
+    it.each([
+        [{ moduleSpecifierStyle: true }, "moduleSpecifierStyle", "expected a string"],
+        [{ terminology: [] }, "terminology", "expected an object"],
+        [{ terminology: { enable: true } }, "terminology.enable", "unknown key"],
+        [{ terminology: { enabled: "true" } }, "terminology.enabled", "expected a boolean"],
+        [{ terminology: { packages: "fixture.ig@1.2.3" } }, "terminology.packages", "expected an array"],
+        [{ terminology: { packageVerification: [] } }, "terminology.packageVerification", "expected an object"],
+        [
+            { terminology: { packageVerification: { fixture: false } } },
+            "terminology.packageVerification.fixture",
+            "expected a string",
+        ],
+    ])("rejects malformed TypeScript options %j", (typescript, path, message) => {
+        const raw = validConfig();
+        raw.builders[0]!.typescript = typescript;
+
+        try {
+            parseGenerateConfig(raw, CONFIG_PATH);
+            throw new Error("expected a GenerateConfigError");
+        } catch (error) {
+            expect(error).toBeInstanceOf(GenerateConfigError);
+            expect((error as GenerateConfigError).issues).toEqual([
+                { path: `builders[0].typescript.${path}`, message: expect.stringContaining(message) },
+            ]);
+        }
+    });
+
     it("rejects an unknown key in a builder and names it", () => {
         const raw = validConfig();
         (raw.builders[0] as Record<string, unknown>).typscript = {};
@@ -337,6 +409,29 @@ describe("parseGenerateConfig", () => {
 });
 
 describe("runGenerateConfig", () => {
+    it("passes TypeScript module and terminology options from JSON to generation", async () => {
+        const raw = validConfig();
+        raw.builders[0]!.typescript = {
+            moduleSpecifierStyle: "node-esm",
+            terminology: {
+                enabled: true,
+                packages: ["fixture.ig@1.2.3", "restricted.ig@2.0.0"],
+                packageVerification: {
+                    "fixture.ig@1.2.3": "publisher-signature",
+                    "restricted.ig@2.0.0": "unverifiable",
+                },
+            },
+        };
+        const config = parseGenerateConfig(raw, CONFIG_PATH);
+        const factory = mkFactory();
+
+        await runGenerateConfig(config, { createBuilder: factory.createBuilder });
+
+        expect(factory.recordings[0]!.calls.find((call) => call.method === "typescript")!.args).toEqual([
+            raw.builders[0]!.typescript,
+        ]);
+    });
+
     it("applies one builder's configuration in a fixed order", async () => {
         const config = parseGenerateConfig(
             {


### PR DESCRIPTION
Our FHIR generation workflow uses JSON configs to produce TypeScript output and terminology for downstream clients. After adopting the terminology and Node ESM options from #218/#219, the same options worked through `APIBuilder` but were rejected as unknown keys by the config-driven command from #211/#217.

This restores parity between the JSON entry point and the existing TypeScript API. We can keep the generation settings in one declarative config; other CLI and CI users can select Node-compatible imports and terminology packages without maintaining a separate TypeScript wrapper script. Invalid nested settings still produce explicit configuration errors.

- Accept `moduleSpecifierStyle` and `terminology` in JSON TypeScript configuration, matching the existing API options.
- Validate module styles and nested terminology settings with precise error paths.
- Forward these options to generation and document JSON usage.
- Raise the `smol-toml` override to `>=1.7.1` and lock `1.8.0` to fix the shared security audit failure (GHSA-7w5x-hrqm-74c2).

Options introduced by #218 and #219 can now be used through the config-driven command from #211/#217.

Before, the parser rejected these keys as unknown. After, the same configuration enables Node ESM imports and selected terminology packages:

```json
{
  "typescript": {
    "moduleSpecifierStyle": "node-esm",
    "terminology": {
      "enabled": true,
      "packages": ["hl7.fhir.r4.core@4.0.1"],
      "packageVerification": {
        "hl7.fhir.r4.core@4.0.1": "registry-integrity"
      }
    }
  }
}
```
