### PR TITLE
TS: Expose resourceType on generated resource profile classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,15 @@ Templates enable flexible code generation for any language or format (Go, Rust, 
 
 When generating TypeScript with `generateProfile: true`, the generator creates profile wrapper classes that provide a fluent API for working with FHIR profiles. These classes handle complex profile constraints like slicing and extensions automatically.
 
+Resource profile classes expose `static readonly resourceType` alongside `canonicalUrl`, `from()` and `createResource()`. A generic FHIR client can use the class itself as a structural descriptor. The resource type comes from the resolved snapshot base; Extension and datatype profile classes do not expose `resourceType`.
+
+```typescript
+import { observation_bodyweightProfile } from "./profiles/Observation_observation_bodyweight";
+
+observation_bodyweightProfile.resourceType; // "Observation"
+observation_bodyweightProfile.canonicalUrl; // "http://hl7.org/fhir/StructureDefinition/bodyweight"
+```
+
 ```typescript
 import { observation_bpProfile as bpProfile } from "./profiles/Observation_observation_bp";
 

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     "minimatch": ">=10.2.3",
     "picomatch": ">=4.0.4",
     "rollup": ">=4.59.0",
-    "smol-toml": ">=1.6.1",
+    "smol-toml": ">=1.7.1",
   },
   "packages": {
     "@atomic-ehr/fhir-canonical-manager": ["@atomic-ehr/fhir-canonical-manager@0.0.24", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "fcm": "dist/cli/index.js" } }, "sha512-3h+uGf3qqxNX2oClVx+Fz1NZ2Jm2h2dXKrbhA77gURmX5TUYYQKxdTh58a7N/tteLLsig5fW8q41wfeUqy7GdQ=="],
@@ -408,7 +408,7 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+    "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 

--- a/docs/design/profiles.md
+++ b/docs/design/profiles.md
@@ -127,8 +127,11 @@ export interface observation_bodyweight extends Observation {
 
 2. **Profile class** — wraps the resource with factory methods, typed getters/setters, slice accessors, extension accessors, and validation:
 
+Resource profile classes also expose `static readonly resourceType`, resolved from the snapshot base. Together with `canonicalUrl`, `from()` and `createResource()`, this lets a generic FHIR client accept the class as a structural descriptor. Extension and datatype profile classes retain `canonicalUrl` without a `resourceType` member.
+
 ```typescript
 export class observation_bodyweightProfile {
+    static readonly resourceType = "Observation"
     static readonly canonicalUrl = "http://hl7.org/fhir/StructureDefinition/bodyweight"
     private resource: Observation
 

--- a/examples/on-the-fly/norge-r4/__snapshots__/kjernejournal-profiles.test.ts.snap
+++ b/examples/on-the-fly/norge-r4/__snapshots__/kjernejournal-profiles.test.ts.snap
@@ -80,6 +80,7 @@ export type KjAllergyIntoleranceProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjAllergyIntolerance (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjAllergyIntoleranceProfile {
+    static readonly resourceType = "AllergyIntolerance";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjAllergyIntolerance";
 
     private resource: AllergyIntolerance;
@@ -512,6 +513,7 @@ export type KjConditionComplicationsOfAnesthesiaProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjConditionComplicationsOfAnesthesia (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjConditionComplicationsOfAnesthesiaProfile {
+    static readonly resourceType = "Condition";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjConditionComplicationsOfAnesthesia";
 
     private static readonly possibilityForVentilationWithMaskSliceMatch: Record<string, unknown> = {
@@ -895,6 +897,7 @@ export type KjConditionCriticalMedicalConditionProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjConditionCriticalMedicalCondition (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjConditionCriticalMedicalConditionProfile {
+    static readonly resourceType = "Condition";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjConditionCriticalMedicalCondition";
 
     private resource: Condition;
@@ -1251,6 +1254,7 @@ export type KjConditionInfectionProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjConditionInfection (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjConditionInfectionProfile {
+    static readonly resourceType = "Condition";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjConditionInfection";
 
     private resource: Condition;
@@ -1630,6 +1634,7 @@ export type KjConditionTransplantsAndOtherForeignBodiesProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjConditionTransplantsAndOtherForeignBodies (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjConditionTransplantsAndOtherForeignBodiesProfile {
+    static readonly resourceType = "Condition";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjConditionTransplantsAndOtherForeignBodies";
 
     private resource: Condition;
@@ -2009,6 +2014,7 @@ export type KjConsentProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjConsent (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjConsentProfile {
+    static readonly resourceType = "Consent";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjConsent";
 
     private resource: Consent;
@@ -2371,6 +2377,7 @@ export type KjDeviceUseStatementProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjDeviceUseStatement (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjDeviceUseStatementProfile {
+    static readonly resourceType = "DeviceUseStatement";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjDeviceUseStatement";
 
     private resource: DeviceUseStatement;
@@ -2673,6 +2680,7 @@ export type KjDeviceProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjDevice (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjDeviceProfile {
+    static readonly resourceType = "Device";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjDevice";
 
     private resource: Device;
@@ -3874,6 +3882,7 @@ export type KjFlagProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjFlag (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjFlagProfile {
+    static readonly resourceType = "Flag";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjFlag";
 
     private static readonly KjCategorySliceMatch: Record<string, unknown> = {
@@ -4224,6 +4233,7 @@ export type KjPractitionerRoleProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjPractitionerRole (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjPractitionerRoleProfile {
+    static readonly resourceType = "PractitionerRole";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjPractitionerRole";
 
     private resource: PractitionerRole;
@@ -4381,6 +4391,7 @@ export type KjProcedureProfileRaw = {
 
 // CanonicalURL: http://nhn.no/kj/fhir/StructureDefinition/KjProcedure (pkg: nhn.fhir.no.kjernejournal#1.0.0)
 export class KjProcedureProfile {
+    static readonly resourceType = "Procedure";
     static readonly canonicalUrl = "http://nhn.no/kj/fhir/StructureDefinition/KjProcedure";
 
     private resource: Procedure;

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_bodyweight.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_bodyweight.ts
@@ -41,6 +41,7 @@ export type observation_bodyweightProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/StructureDefinition/bodyweight (pkg: hl7.fhir.r4.core#4.0.1)
 export class observation_bodyweightProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/StructureDefinition/bodyweight";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_bp.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_bp.ts
@@ -50,6 +50,7 @@ export type observation_bpProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/StructureDefinition/bp (pkg: hl7.fhir.r4.core#4.0.1)
 export class observation_bpProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/StructureDefinition/bp";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_vitalsigns.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-r4-core/profiles/Observation_observation_vitalsigns.ts
@@ -40,6 +40,7 @@ export type observation_vitalsignsProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/StructureDefinition/vitalsigns (pkg: hl7.fhir.r4.core#4.0.1)
 export class observation_vitalsignsProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/StructureDefinition/vitalsigns";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Observation_USCoreBloodPressureProfile.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Observation_USCoreBloodPressureProfile.ts
@@ -53,6 +53,7 @@ export type USCoreBloodPressureProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure (pkg: hl7.fhir.us.core#8.0.1)
 export class USCoreBloodPressureProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Observation_USCoreBodyWeightProfile.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Observation_USCoreBodyWeightProfile.ts
@@ -44,6 +44,7 @@ export type USCoreBodyWeightProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight (pkg: hl7.fhir.us.core#8.0.1)
 export class USCoreBodyWeightProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Observation_USCoreVitalSignsProfile.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Observation_USCoreVitalSignsProfile.ts
@@ -44,6 +44,7 @@ export type USCoreVitalSignsProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs (pkg: hl7.fhir.us.core#8.0.1)
 export class USCoreVitalSignsProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {

--- a/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Patient_USCorePatientProfile.ts
+++ b/examples/typescript-r4-us-core/fhir-types/hl7-fhir-us-core/profiles/Patient_USCorePatientProfile.ts
@@ -47,6 +47,7 @@ export type USCorePatientProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient (pkg: hl7.fhir.us.core#8.0.1)
 export class USCorePatientProfile {
+    static readonly resourceType = "Patient";
     static readonly canonicalUrl = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient";
 
     private resource: Patient;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "overrides": {
     "minimatch": ">=10.2.3",
     "rollup": ">=4.59.0",
-    "smol-toml": ">=1.6.1",
+    "smol-toml": ">=1.7.1",
     "brace-expansion": "^5.0.9",
     "picomatch": ">=4.0.4",
     "esbuild": ">=0.28.1"

--- a/src/api/writer-generator/typescript/profile-resource-type.ts
+++ b/src/api/writer-generator/typescript/profile-resource-type.ts
@@ -1,0 +1,27 @@
+import { isResourceIdentifier, type TypeIdentifier } from "@root/typeschema/types";
+
+/**
+ * Resolve the FHIR resource type literal for a generated resource-profile class
+ * from the snapshot base only. Does not inspect filenames, canonical URLs, or
+ * class names.
+ */
+export const resolveProfileResourceType = (base: TypeIdentifier | undefined): string => {
+    if (!base) throw new Error("Cannot resolve FHIR resource type: snapshot base is missing");
+    if (!base.name.trim()) throw new Error("Cannot resolve FHIR resource type: snapshot base name is empty");
+    if (!isResourceIdentifier(base))
+        throw new Error(
+            `Cannot resolve FHIR resource type: snapshot base '${base.name}' is not a supported FHIR StructureDefinition root`,
+        );
+    return base.name;
+};
+
+/** Always calls `resolveProfileResourceType`. Returns the literal or the thrown reason. */
+export const tryResolveProfileResourceType = (
+    base: TypeIdentifier | undefined,
+): { resourceType: string } | { error: string } => {
+    try {
+        return { resourceType: resolveProfileResourceType(base) };
+    } catch (error) {
+        return { error: error instanceof Error ? error.message : String(error) };
+    }
+};

--- a/src/api/writer-generator/typescript/profile.ts
+++ b/src/api/writer-generator/typescript/profile.ts
@@ -32,6 +32,7 @@ import {
     generateExtensionMethods,
     resolveExtensionProfile,
 } from "./profile-extensions";
+import { tryResolveProfileResourceType } from "./profile-resource-type";
 import {
     collectRequiredSliceNames,
     collectSliceDefs,
@@ -826,6 +827,16 @@ export const generateProfileClass = (w: TypeScript, tsIndex: TypeSchemaIndex, sn
     w.comment("CanonicalURL:", canonicalUrl, `(pkg: ${packageMetaToFhir(packageMeta(snapshot))})`);
 
     w.curlyBlock(["export", "class", profileClassName], () => {
+        if (isResourceIdentifier(snapshot.base)) {
+            const resolved = tryResolveProfileResourceType(snapshot.base);
+            if ("resourceType" in resolved) {
+                w.lineSM(`static readonly resourceType = ${JSON.stringify(resolved.resourceType)}`);
+            } else {
+                w.logger()?.error(
+                    `Cannot emit static resourceType for profile '${profileClassName}': ${resolved.error}`,
+                );
+            }
+        }
         w.lineSM(`static readonly canonicalUrl = ${JSON.stringify(canonicalUrl)}`);
         w.line();
         generateStaticSliceFields(w, sliceDefs);

--- a/test/api/write-generator/__snapshots__/kbv-condition-diagnosis.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/kbv-condition-diagnosis.test.ts.snap
@@ -3567,6 +3567,7 @@ export type KBV_PR_Base_Condition_DiagnosisProfileRaw = {
 
 // CanonicalURL: https://fhir.kbv.de/StructureDefinition/KBV_PR_Base_Condition_Diagnosis (pkg: kbv.basis#1.9.0)
 export class KBV_PR_Base_Condition_DiagnosisProfile {
+    static readonly resourceType = "Condition";
     static readonly canonicalUrl = "https://fhir.kbv.de/StructureDefinition/KBV_PR_Base_Condition_Diagnosis";
 
     private resource: Condition;

--- a/test/api/write-generator/__snapshots__/profile-slice-corrections.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/profile-slice-corrections.test.ts.snap
@@ -46,6 +46,7 @@ export type SystemOnlyCodingObservationProfileRaw = {
 
 // CanonicalURL: http://example.org/StructureDefinition/system-only-coding (pkg: codegen.test#1.0.0)
 export class SystemOnlyCodingObservationProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://example.org/StructureDefinition/system-only-coding";
 
     private resource: Observation;
@@ -185,6 +186,7 @@ export type CollidingSliceObservationProfileRaw = {
 
 // CanonicalURL: http://example.org/StructureDefinition/colliding-slice (pkg: codegen.test#1.0.0)
 export class CollidingSliceObservationProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://example.org/StructureDefinition/colliding-slice";
 
     private static readonly categorySliceMatch: Record<string, unknown> = {
@@ -357,6 +359,7 @@ export type InheritedCollisionObservationProfileRaw = {
 
 // CanonicalURL: http://example.org/StructureDefinition/inherited-collision (pkg: codegen.test#1.0.0)
 export class InheritedCollisionObservationProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://example.org/StructureDefinition/inherited-collision";
 
     private static readonly categorySliceMatch: Record<string, unknown> = {

--- a/test/api/write-generator/__snapshots__/typescript.test.ts.snap
+++ b/test/api/write-generator/__snapshots__/typescript.test.ts.snap
@@ -544,6 +544,7 @@ export type observation_bodyweightProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/StructureDefinition/bodyweight (pkg: hl7.fhir.r4.core#4.0.1)
 export class observation_bodyweightProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/StructureDefinition/bodyweight";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {
@@ -786,6 +787,7 @@ export type observation_bpProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/StructureDefinition/bp (pkg: hl7.fhir.r4.core#4.0.1)
 export class observation_bpProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/StructureDefinition/bp";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {
@@ -1101,6 +1103,7 @@ export type USCorePatientProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient (pkg: hl7.fhir.us.core#8.0.1)
 export class USCorePatientProfile {
+    static readonly resourceType = "Patient";
     static readonly canonicalUrl = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient";
 
     private resource: Patient;
@@ -1371,6 +1374,7 @@ export type USCoreBloodPressureProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure (pkg: hl7.fhir.us.core#8.0.1)
 export class USCoreBloodPressureProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {
@@ -1799,6 +1803,7 @@ export type USCoreBodyWeightProfileRaw = {
 
 // CanonicalURL: http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight (pkg: hl7.fhir.us.core#8.0.1)
 export class USCoreBodyWeightProfile {
+    static readonly resourceType = "Observation";
     static readonly canonicalUrl = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight";
 
     private static readonly VSCatSliceMatch: Record<string, unknown> = {

--- a/test/api/write-generator/multi-package/__snapshots__/local-package.test.ts.snap
+++ b/test/api/write-generator/multi-package/__snapshots__/local-package.test.ts.snap
@@ -70,6 +70,7 @@ export type ExampleTypedBundleProfileRaw = {
 
 // CanonicalURL: http://example.org/fhir/StructureDefinition/ExampleTypedBundle (pkg: example.folder.structures#0.0.1)
 export class ExampleTypedBundleProfile {
+    static readonly resourceType = "Bundle";
     static readonly canonicalUrl = "http://example.org/fhir/StructureDefinition/ExampleTypedBundle";
 
     private static readonly PatientEntrySliceMatch: Record<string, unknown> = {"resource":{"resourceType":"Patient"}};

--- a/test/unit/api/writer-generator/typescript/profile-descriptor.test.ts
+++ b/test/unit/api/writer-generator/typescript/profile-descriptor.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { APIBuilder } from "@root/api/builder";
+import { mkErrorLogger, r4Manager } from "@typeschema-test/utils";
+
+const PROFILE_PATH = "generated/types/hl7-fhir-r4-core/profiles/Observation_observation_bodyweight.ts";
+const PROFILE_IMPORT = "./generated/types/hl7-fhir-r4-core/profiles/Observation_observation_bodyweight";
+const TSC_PATH = Bun.resolveSync("typescript/bin/tsc", import.meta.dir);
+
+const consumerSource = `import { observation_bodyweightProfile } from "${PROFILE_IMPORT}";
+
+type ProfileDescriptor = {
+    readonly resourceType: string;
+    readonly canonicalUrl: string;
+    from(resource: unknown): unknown;
+    createResource(args: unknown): unknown;
+};
+
+const _descriptor: ProfileDescriptor = observation_bodyweightProfile;
+const _resourceType: "Observation" = observation_bodyweightProfile.resourceType;
+// @ts-expect-error The descriptor cannot be changed by callers.
+observation_bodyweightProfile.resourceType = "Patient";
+void [_descriptor, _resourceType];
+`;
+
+describe("generated profile structural descriptor", () => {
+    test("a generated profile class is assignable to a generic FHIR client descriptor", async () => {
+        const result = await new APIBuilder({ register: r4Manager, logger: mkErrorLogger() })
+            .typeSchema({
+                treeShake: {
+                    "hl7.fhir.r4.core": {
+                        "http://hl7.org/fhir/StructureDefinition/bodyweight": {},
+                    },
+                },
+            })
+            .typescript({
+                inMemoryOnly: true,
+                withDebugComment: false,
+                generateProfile: true,
+                openResourceTypeSet: false,
+            })
+            .generate();
+
+        expect(result.success).toBeTrue();
+        const files = result.filesGenerated.typescript!;
+        expect(files[PROFILE_PATH]).toBeDefined();
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "profile-descriptor-"));
+        try {
+            for (const [relPath, content] of Object.entries(files)) {
+                const absPath = path.join(tmpDir, relPath);
+                fs.mkdirSync(path.dirname(absPath), { recursive: true });
+                fs.writeFileSync(absPath, content);
+            }
+            const { observation_bodyweightProfile } = await import(path.join(tmpDir, PROFILE_PATH));
+            expect(observation_bodyweightProfile.resourceType).toBe("Observation");
+            expect(observation_bodyweightProfile.canonicalUrl).toBe(
+                "http://hl7.org/fhir/StructureDefinition/bodyweight",
+            );
+            const resource = observation_bodyweightProfile.createResource({ status: "final" });
+            expect(resource.resourceType).toBe(observation_bodyweightProfile.resourceType);
+            fs.writeFileSync(path.join(tmpDir, "consumer.ts"), consumerSource);
+            fs.writeFileSync(
+                path.join(tmpDir, "tsconfig.json"),
+                JSON.stringify({
+                    compilerOptions: {
+                        strict: true,
+                        module: "esnext",
+                        moduleResolution: "bundler",
+                        target: "esnext",
+                        skipLibCheck: true,
+                        noEmit: true,
+                    },
+                    include: ["consumer.ts", "generated/**/*.ts"],
+                }),
+            );
+
+            const tsc = spawnSync(process.execPath, [TSC_PATH, "--noEmit", "-p", "tsconfig.json"], {
+                cwd: tmpDir,
+                encoding: "utf8",
+                timeout: 20_000,
+            });
+            expect(tsc.status, `${tsc.error?.message ?? ""}${tsc.stdout}${tsc.stderr}`).toBe(0);
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    }, 30_000);
+});

--- a/test/unit/api/writer-generator/typescript/profile-resource-type-writer.test.ts
+++ b/test/unit/api/writer-generator/typescript/profile-resource-type-writer.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { generateProfileClass } from "@root/api/writer-generator/typescript/profile";
+import { TypeScript } from "@root/api/writer-generator/typescript/writer";
+import type {
+    CanonicalUrl,
+    ComplexTypeTypeSchema,
+    Name,
+    PrimitiveTypeSchema,
+    ResourceTypeSchema,
+    SnapshotProfileTypeSchema,
+    TypeIdentifier,
+} from "@root/typeschema/types";
+import { mkTypeSchemaIndex } from "@root/typeschema/utils";
+import { mkCodegenLogger } from "@root/utils/log";
+
+const primitiveBase: TypeIdentifier = {
+    kind: "primitive-type",
+    name: "base64Binary" as Name,
+    package: "hl7.fhir.r4.core",
+    version: "4.0.1",
+    url: "http://hl7.org/fhir/StructureDefinition/base64Binary" as CanonicalUrl,
+};
+
+const elementBase: TypeIdentifier = {
+    kind: "complex-type",
+    name: "Element" as Name,
+    package: "hl7.fhir.r4.core",
+    version: "4.0.1",
+    url: "http://hl7.org/fhir/StructureDefinition/Element" as CanonicalUrl,
+};
+
+const primitiveSchema: PrimitiveTypeSchema = {
+    identifier: primitiveBase,
+    base: elementBase,
+};
+
+const makeBase = (kind: "resource" | "complex-type", name: string): TypeIdentifier => ({
+    kind,
+    name: name as Name,
+    package: "hl7.fhir.r4.core",
+    version: "4.0.1",
+    url: `http://hl7.org/fhir/StructureDefinition/${name}` as CanonicalUrl,
+});
+
+const makeSnapshot = (name: string, base: TypeIdentifier): SnapshotProfileTypeSchema => ({
+    identifier: {
+        kind: "profile-snapshot",
+        name: name as Name,
+        package: "codegen.test",
+        version: "1.0.0",
+        url: `http://example.org/StructureDefinition/${name}` as CanonicalUrl,
+    },
+    base,
+    fields: {},
+});
+
+const resourceBase = makeBase("resource", "Observation");
+const extensionBase = makeBase("complex-type", "Extension");
+const datatypeBase = makeBase("complex-type", "Address");
+const resourceSchema: ResourceTypeSchema = {
+    identifier: resourceBase as ResourceTypeSchema["identifier"],
+};
+const extensionSchema: ComplexTypeTypeSchema = {
+    identifier: extensionBase as ComplexTypeTypeSchema["identifier"],
+};
+const datatypeSchema: ComplexTypeTypeSchema = {
+    identifier: datatypeBase as ComplexTypeTypeSchema["identifier"],
+};
+const generateProfile = (
+    snapshot: SnapshotProfileTypeSchema,
+    schemas: Array<ResourceTypeSchema | ComplexTypeTypeSchema | PrimitiveTypeSchema>,
+) => {
+    const logger = mkCodegenLogger({ level: "ERROR" });
+    const w = new TypeScript({
+        outputDir: "/tmp/profile-resource-type",
+        inMemoryOnly: true,
+        tabSize: 4,
+        commentLinePrefix: "//",
+        logger,
+        openResourceTypeSet: false,
+        primitiveTypeExtension: true,
+        generateProfile: true,
+    });
+    const tsIndex = mkTypeSchemaIndex(schemas, { logger });
+    w.cd("/", () => {
+        w.cat(`${snapshot.identifier.name}Profile.ts`, () => {
+            generateProfileClass(w, tsIndex, snapshot);
+        });
+    });
+    const generated = w.writtenFiles()[0]?.content ?? "";
+    return { logger, generated };
+};
+
+describe("TypeScript profile writer resourceType descriptor", () => {
+    test("emits static resourceType for a resource profile", () => {
+        const { logger, generated } = generateProfile(makeSnapshot("BodyWeight", resourceBase), [resourceSchema]);
+
+        expect(logger.buffer().filter((entry) => entry.level === "ERROR")).toEqual([]);
+        expect(generated).toContain('static readonly resourceType = "Observation"');
+    });
+
+    // Complex and primitive profiles do not
+    // represent FHIR resources and must not expose a resourceType descriptor.
+    test.each([
+        ["ExtensionProfile", extensionBase, extensionSchema],
+        ["AddressProfile", datatypeBase, datatypeSchema],
+        ["PrimitiveProfile", primitiveBase, primitiveSchema],
+    ])("omits static resourceType for non-resource profile %s", (name, base, schema) => {
+        const { logger, generated } = generateProfile(makeSnapshot(name, base), [schema]);
+
+        expect(logger.buffer().filter((entry) => entry.level === "ERROR")).toEqual([]);
+        expect(generated).toContain(`export class ${name}`);
+        expect(generated).not.toContain("static readonly resourceType");
+    });
+});

--- a/test/unit/api/writer-generator/typescript/resolve-profile-resource-type.test.ts
+++ b/test/unit/api/writer-generator/typescript/resolve-profile-resource-type.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { resolveProfileResourceType } from "@root/api/writer-generator/typescript/profile-resource-type";
+import type { CanonicalUrl, Name, TypeIdentifier } from "@root/typeschema/types";
+
+const makeIdentifier = (
+    kind: TypeIdentifier["kind"],
+    name: string,
+    url = `http://example.org/StructureDefinition/${name}`,
+): TypeIdentifier => ({
+    kind,
+    package: "test-package",
+    version: "1.0.0",
+    name: name as Name,
+    url: url as CanonicalUrl,
+});
+
+describe("resolveProfileResourceType", () => {
+    test("resource base returns the resolved type name", () => {
+        expect(resolveProfileResourceType(makeIdentifier("resource", "Observation"))).toBe("Observation");
+    });
+
+    test("Bundle resource base returns Bundle", () => {
+        expect(resolveProfileResourceType(makeIdentifier("resource", "Bundle"))).toBe("Bundle");
+    });
+
+    test("throws for an Extension complex-type base", () => {
+        expect(() => resolveProfileResourceType(makeIdentifier("complex-type", "Extension"))).toThrow(
+            /supported FHIR|not a supported/i,
+        );
+    });
+
+    test("throws for a datatype complex-type base", () => {
+        expect(() => resolveProfileResourceType(makeIdentifier("complex-type", "Address"))).toThrow(
+            /supported FHIR|not a supported/i,
+        );
+    });
+
+    test("uses the resolved base name when a decoy URL would imply a different type", () => {
+        const decoy = makeIdentifier("resource", "Observation", "http://hl7.org/fhir/StructureDefinition/Patient");
+        expect(resolveProfileResourceType(decoy)).toBe("Observation");
+    });
+
+    test("throws when the base is missing", () => {
+        expect(() => resolveProfileResourceType(undefined)).toThrow(/supported FHIR|snapshot base|resource type/i);
+    });
+
+    test("throws when the base name is empty", () => {
+        expect(() => resolveProfileResourceType(makeIdentifier("resource", ""))).toThrow(
+            /supported FHIR|snapshot base|resource type/i,
+        );
+    });
+
+    test("throws for a primitive base", () => {
+        expect(() => resolveProfileResourceType(makeIdentifier("primitive-type", "string"))).toThrow(
+            /supported FHIR|not a supported/i,
+        );
+    });
+
+    test("throws for an unsupported logical base", () => {
+        expect(() => resolveProfileResourceType(makeIdentifier("logical", "ExampleNotebook"))).toThrow(
+            /supported FHIR|not a supported/i,
+        );
+    });
+
+    test("throws for a profile identifier used as base", () => {
+        expect(() => resolveProfileResourceType(makeIdentifier("profile", "USCorePatient"))).toThrow(
+            /supported FHIR|not a supported/i,
+        );
+    });
+
+    test("throws for a nested identifier used as base", () => {
+        expect(() => resolveProfileResourceType(makeIdentifier("nested", "Patient.contact"))).toThrow(
+            /supported FHIR|not a supported/i,
+        );
+    });
+});


### PR DESCRIPTION
Our profile-bound FHIR client needs both the profile canonical and its base resource type. Generated profile classes already provide `canonicalUrl`, parsing and factory methods, but lack static resource-type metadata. Callers consequently have to supply an extra string such as `"Observation"` or maintain a separate mapping, which can drift from the profile definition.

The generator already resolves the snapshot base, so it can emit that metadata once at its authoritative source. This lets us pass a generated resource-profile class directly as a client descriptor. Other generic FHIR clients, routing helpers and profile registries can use the same structural metadata without parsing class names or adding a dependency on our SDK. Extension and datatype profiles remain excluded because they are not FHIR resources.

- Add static readonly `resourceType` metadata derived from the resource profile's snapshot base.
- Keep Extension and datatype profile classes free of resource-type metadata.
- Cover structural descriptor compatibility, literal typing, runtime values, and compilation with the project TypeScript compiler.
- Document descriptor usage and regenerate affected examples and snapshots.
- Raise the `smol-toml` override to `>=1.7.1` and lock `1.8.0` to fix the shared security audit failure (GHSA-7w5x-hrqm-74c2).

Resource profile classes can supply their FHIR resource type directly to generic clients.

Before:
```typescript
export class observation_bodyweightProfile {
    static readonly canonicalUrl = "http://hl7.org/fhir/StructureDefinition/bodyweight";
}
```

After:
```typescript
export class observation_bodyweightProfile {
    static readonly resourceType = "Observation";
    static readonly canonicalUrl = "http://hl7.org/fhir/StructureDefinition/bodyweight";
}
```
